### PR TITLE
Added Multi-Templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ components:
 * **Inherit** functionality from other prototypes:
 
   >  ```yaml
-  >  name: Enemy
-  >  template: Creature
+  >  name: Skeleton
+  >  templates: Enemy, Creature
   >  components:
   >    # ...
   >  ```
@@ -199,7 +199,7 @@ Then inherit the template in another Prototype:
 # assets/prototypes/peasant.yaml
 ---
 name: "Peasant"
-template: "NPC"
+template: NPC
 ```
 
 You can also override template components:
@@ -208,10 +208,25 @@ You can also override template components:
 # assets/prototypes/adventurer.yaml
 ---
 name: "Adventurer"
+template: NPC
 components:
   - type: Inventory
     value: ["sword"]
 ```
+
+Multiple templates can be specified as well. However, conflicting components will be overridden in reverse order (templates listed first can override templates listed last):
+
+```yaml
+# assets/prototypes/fast_adventurer.yaml
+---
+name: "Fast Adventurer"
+templates: Speedy, NPC # "Speedy" may override "NPC"
+components:
+  - type: Inventory
+    value: ["sword"]
+```
+
+> Templates can be specified as a standard YAML list or as a comma-separated string (like in the example above). Additionally,  `templates` is an alias for `template`, so either one may be used.
 
 ### Spawning the Prototype
 

--- a/README.md
+++ b/README.md
@@ -347,11 +347,9 @@ The default Prototype object looks like this:
 pub struct Prototype {
     /// The name of this prototype
 	  pub name: String,
-	  /// The name of this prototype's template (if any)
-	  #[serde(default)]
-	  pub template: Option<String>,
+	  /// The names of this prototype's templates (if any)
+	  pub templates: Vec<String>,
 	  /// The components belonging to this prototype
-	  #[serde(default)]
 	  pub components: Vec<Box<dyn ProtoComponent>>,
 }
 ```

--- a/assets/prototypes/templates/alice.yaml
+++ b/assets/prototypes/templates/alice.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Alice"
-templates: NPC
+template: NPC
 components:
   - type: Named
     value: "Alice Allison"

--- a/assets/prototypes/templates/alice.yaml
+++ b/assets/prototypes/templates/alice.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Alice"
-template: "NPC"
+templates: NPC
 components:
   - type: Named
     value: "Alice Allison"

--- a/assets/prototypes/templates/bob.yaml
+++ b/assets/prototypes/templates/bob.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Bob"
-template: "NPC"
+templates: NPC
 components:
   - type: Named
     value: "Bob Roberts"

--- a/assets/prototypes/templates/bob.yaml
+++ b/assets/prototypes/templates/bob.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Bob"
-templates: NPC
+template: NPC
 components:
   - type: Named
     value: "Bob Roberts"

--- a/assets/prototypes/templates/healthy.template.yaml
+++ b/assets/prototypes/templates/healthy.template.yaml
@@ -1,0 +1,6 @@
+---
+name: Healthy
+components:
+  - type: Health
+    value:
+      max: 30

--- a/assets/prototypes/templates/mystery.yaml
+++ b/assets/prototypes/templates/mystery.yaml
@@ -1,3 +1,3 @@
 ---
 name: "Mystery"
-templates: NPC
+template: NPC

--- a/assets/prototypes/templates/mystery.yaml
+++ b/assets/prototypes/templates/mystery.yaml
@@ -1,3 +1,3 @@
 ---
 name: "Mystery"
-template: "NPC"
+templates: NPC

--- a/assets/prototypes/templates/urist.yaml
+++ b/assets/prototypes/templates/urist.yaml
@@ -1,11 +1,18 @@
 ---
 name: "Urist"
-template: "NPC"
+
+# Templates are applied in reverse order. So templates listed first override templates listed last.
+templates:
+  - Healthy
+  - NPC
+  -
+# Templates can also be listed inline:
+#   templates: [ Healthy, NPC ]
+# Or without brackets (deserialized as a comma-separated string):
+#   templates: Healthy, NPC
+
 components:
   - type: Named
     value: "Urist McTemplate"
   - type: Occupation
     value: Miner
-  - type: Health
-    value:
-      max: 30

--- a/assets/prototypes/templates/urist.yaml
+++ b/assets/prototypes/templates/urist.yaml
@@ -5,7 +5,6 @@ name: "Urist"
 templates:
   - Healthy
   - NPC
-  -
 # Templates can also be listed inline:
 #   templates: [ Healthy, NPC ]
 # Or without brackets (deserialized as a comma-separated string):

--- a/src/data.rs
+++ b/src/data.rs
@@ -94,7 +94,7 @@ impl ProtoData {
 	///     };
 	///     let proto = Prototype {
 	///         name: String::from("My Prototype"),
-	///         template: None,
+	///         templates: Vec::default(),
 	///         components: vec![Box::new(comp)]
 	///     };
 	///
@@ -280,18 +280,18 @@ fn analyze_deps(data: &ProtoData) {
 	) {
 		traversed.insert(proto.name());
 
-		match proto.template() {
-			Some(template_name) if traversed.contains(template_name) => {
+		for template in proto.templates_rev() {
+			if traversed.contains(template.as_str()) {
 				// ! --- Found Circular Dependency --- ! //
-				handle_cycle!(template_name, traversed);
+				handle_cycle!(template, traversed);
+
+				continue;
 			}
-			Some(template_name) => {
-				if let Some(parent) = data.get_prototype(template_name) {
-					// --- Check Template --- //
-					check_for_cycles(parent, data, traversed);
-				}
+
+			if let Some(parent) = data.get_prototype(template) {
+				// --- Check Template --- //
+				check_for_cycles(parent, data, traversed);
 			}
-			_ => (),
 		}
 	};
 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -156,7 +156,9 @@ fn spawn_internal<'a>(
 pub struct Prototype {
 	/// The name of this prototype
 	pub name: String,
-	/// The name of this prototype's template (if any)
+	/// The names of this prototype's templates (if any)
+	///
+	/// See [`deserialize_templates_list`], for how these names are deserialized.
 	#[serde(default)]
 	#[serde(alias = "template")]
 	#[serde(deserialize_with = "deserialize_templates_list")]

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -158,6 +158,7 @@ pub struct Prototype {
 	pub name: String,
 	/// The name of this prototype's template (if any)
 	#[serde(default)]
+	#[serde(alias = "template")]
 	#[serde(deserialize_with = "deserialize_templates_list")]
 	pub templates: Vec<String>,
 	/// The components belonging to this prototype


### PR DESCRIPTION
# Goal

Allows for prototypes to define multiple templates, as suggested here: https://github.com/MrGVSV/bevy_proto/pull/2#discussion_r758901050.

## Example

We can define templates the same as before:

```yaml
template: A
```

However, we can now specify a collection of templates:

```yaml
templates:
  - A
  - B
  - C
```

> `templates` and `template` are interchangeable

We can also define templates as a comma-separated string (for ease of use):

```yaml
templates: A, B, C  # AKA: "A, B, C"
```

## Multiple Inheritance

One concern with allowing for multiple templates is dealing with the issues of multiple inheritance and possible conflicts that arise from it.

The templating system solves conflicts by simply overriding the components in other templates. 

It does so in _**reverse order**_.

So if we want a component in _B_ to override a conflicting component in _A_, we must define it like:

```yaml
templates: B, A
```

The reason we do it in reverse order is to better display specificity. More generic templates are listed last since they are (often) less specific. This keeps the most pertinent templates closer to the prototype being defined:

```yaml
name: "Granny Smith"
templates:
  - Apple # Very Specific
  - Fruit
  - Food
  - Thing # Very Generic
```

# Tasks

- [x] Add functionality
- [x] Update example to showcase it
- [x] Merge #2 
- [x] Update README