### PR TITLE
fix some clippy errors

### DIFF
--- a/bevy_proto_derive/src/lib.rs
+++ b/bevy_proto_derive/src/lib.rs
@@ -21,8 +21,8 @@ mod constants;
 ///
 /// #[derive(Clone, Serialize, Deserialize, ProtoComponent)]
 /// struct SomeComponent {
-/// 	some_string: String,
-/// 	some_int: i32,
+///     some_string: String,
+///     some_int: i32,
 /// }
 ///
 /// // Which generates:

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -37,7 +37,7 @@ impl ProtoComponent for Person {
 /// ```
 /// #[derive(Clone, Serialize, Deserialize, Component, ProtoComponent)]
 /// struct Person {
-/// 	pub name: String,
+///     pub name: String,
 /// }
 /// ```
 #[derive(Copy, Clone, Serialize, Deserialize, ProtoComponent, Component)]

--- a/src/components.rs
+++ b/src/components.rs
@@ -8,5 +8,5 @@ use crate::prototype::Prototypical;
 pub trait ProtoComponent: Send + Sync + 'static {
 	fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>);
 	#[allow(unused_variables)]
-	fn prepare(&self, world: &mut World, prototype: &Box<dyn Prototypical>, data: &mut ProtoData) {}
+	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {}
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -104,7 +104,7 @@ impl ProtoData {
 	/// ```
 	pub fn insert_handle<T: Asset>(
 		&mut self,
-		protoytpe: &Box<dyn Prototypical>,
+		protoytpe: &dyn Prototypical,
 		component: &dyn ProtoComponent,
 		path: &HandlePath,
 		handle: Handle<T>,

--- a/src/data.rs
+++ b/src/data.rs
@@ -26,6 +26,8 @@ impl Deref for HandlePath {
 	}
 }
 
+type UuidHandleMap = HashMap<Uuid, HandleUntyped>;
+
 /// A resource containing data for all prototypes that need data stored
 pub struct ProtoData {
 	/// Maps Prototype Name -> Component Type -> HandlePath -> Asset Type -> HandleUntyped
@@ -35,10 +37,7 @@ pub struct ProtoData {
 			TypeId, // Component Type
 			HashMap<
 				String, // Handle Path
-				HashMap<
-					Uuid,          // Asset UUID
-					HandleUntyped, // Handle
-				>,
+				UuidHandleMap,
 			>,
 		>,
 	>,
@@ -46,7 +45,7 @@ pub struct ProtoData {
 }
 
 impl ProtoData {
-	pub fn new() -> Self {
+	pub fn empty() -> Self {
 		Self {
 			handles: HashMap::default(),
 			prototypes: HashMap::default(),
@@ -443,7 +442,7 @@ pub trait ProtoDeserializer: DynClone {
 	///         Some(Box::new(value))
 	///     } else {
 	///         None
-	///     }
+	///    }
 	/// }
 	/// ```
 	fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>>;

--- a/src/data.rs
+++ b/src/data.rs
@@ -112,13 +112,13 @@ impl ProtoData {
 		let proto_map = self
 			.handles
 			.entry(protoytpe.name().to_string())
-			.or_insert(HashMap::default());
+			.or_insert_with(HashMap::default);
 		let comp_map = proto_map
 			.entry(component.type_id())
-			.or_insert(HashMap::default());
+			.or_insert_with(HashMap::default);
 		let path_map = comp_map
 			.entry(path.to_string())
-			.or_insert(HashMap::default());
+			.or_insert_with(HashMap::default);
 		path_map.insert(T::TYPE_UUID, handle.clone_untyped());
 	}
 
@@ -250,7 +250,7 @@ fn process_path(
 	extensions: &Option<Vec<&str>>,
 	deserializer: &Box<dyn ProtoDeserializer + Send + Sync>,
 	myself: &mut ProtoData,
-	directory: &String,
+	directory: &str,
 	recursive: bool,
 ) {
 	if let Ok(dir) = std::fs::read_dir(directory) {
@@ -275,7 +275,7 @@ fn process_path(
 
 			if let Some(filters) = &extensions {
 				if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-					if filters.iter().find(|filter| *filter == &ext).is_none() {
+					if !filters.iter().any(|filter| filter == &ext) {
 						continue;
 					}
 				}

--- a/src/data.rs
+++ b/src/data.rs
@@ -439,11 +439,11 @@ pub trait ProtoDeserializer: DynClone {
 	/// // The default implementation:
 	/// use bevy_proto::{Prototype, Prototypical};
 	/// fn example_deserialize(data: &str) -> Option<Box<dyn Prototypical>> {
-	/// 	if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
-	///  		Some(Box::new(value))
-	///  	} else {
-	/// 		None
-	///  	}
+	///     if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
+	///         Some(Box::new(value))
+	///     } else {
+	///         None
+	///     }
 	/// }
 	/// ```
 	fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>>;
@@ -466,10 +466,10 @@ pub struct ProtoDataOptions {
 	/// use bevy_proto::ProtoDataOptions;
 	///
 	/// let opts = ProtoDataOptions {
-	/// 	directories: vec![String::from("assets/prototypes")],
-	///	    recursive_loading: true,
-	/// 	extensions: Some(vec!["yaml"]),
-	/// 	..Default::default()
+	///     directories: vec![String::from("assets/prototypes")],
+	///     recursive_loading: true,
+	///     extensions: Some(vec!["yaml"]),
+	///     ..Default::default()
 	/// };
 	/// ```
 	pub recursive_loading: bool,
@@ -486,9 +486,9 @@ pub struct ProtoDataOptions {
 	/// use bevy_proto::ProtoDataOptions;
 	///
 	/// let opts = ProtoDataOptions {
-	/// 	// Only allow .yaml or .json files
-	/// 	extensions: Some(vec!["yaml", "json"]),
-	/// 	..Default::default()
+	///     // Only allow .yaml or .json files
+	///     extensions: Some(vec!["yaml", "json"]),
+	///     ..Default::default()
 	/// };
 	/// ```
 	pub extensions: Option<Vec<&'static str>>,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -5,6 +5,7 @@ use crate::{
 	prototype::{Prototype, Prototypical},
 };
 
+#[derive(Default)]
 pub struct ProtoPlugin {
 	pub options: Option<ProtoDataOptions>,
 }
@@ -118,12 +119,6 @@ impl ProtoPlugin {
 				extensions: Some(vec!["yaml", "json"]),
 			}),
 		}
-	}
-}
-
-impl Default for ProtoPlugin {
-	fn default() -> Self {
-		Self { options: None }
 	}
 }
 

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -4,7 +4,7 @@ use std::slice::Iter;
 
 use bevy::ecs::prelude::Commands;
 use bevy::ecs::system::EntityCommands;
-use bevy::prelude::{AssetServer, Entity, Res};
+use bevy::prelude::{AssetServer, Res};
 use indexmap::IndexSet;
 use serde::{
 	de::{self, Error, SeqAccess, Visitor},

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -124,7 +124,7 @@ pub trait Prototypical: 'static + Send + Sync {
 	///     "#).unwrap();
 	///
 	///     // Get the EntityCommands for the player entity
-	/// 	let entity = commands.entity(player.single().0);
+	///     let entity = commands.entity(player.single().0);
 	///
 	///     // Insert the new components
 	///     let entity = proto.insert(entity, &data, &asset_server).id();

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -278,7 +278,7 @@ where
 		{
 			// Split string by commas
 			// Allowing for: "A, B, C" to become [A, B, C]
-			Ok(v.split(",").map(|s| s.trim().to_string()).collect())
+			Ok(v.split(',').map(|s| s.trim().to_string()).collect())
 		}
 
 		fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
Running `cargo clippy` currently comes up with a few errors. I fixed some of them in this commit.

A few others come up that I wanted to mention:
- Errors around [borrowed boxes](https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box). I think we can replace some of the `&Box` fields with just `&` where clippy tells us to.
- Errors around [tabs in doc comments](https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box). This can cause some issues for generated doc pages.

I also don't know how strongly you are attached to your current `rustfmt.toml` settings, but I would prefer to follow rust community style-guides where possible.