### PR TITLE
fix examples broken by signature change

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -99,7 +99,7 @@ impl ProtoComponent for SpriteBundleDef {
 		commands.insert_bundle(my_bundle);
 	}
 
-	fn prepare(&self, world: &mut World, prototype: &Box<dyn Prototypical>, data: &mut ProtoData) {
+	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
 		// === Load Handles === //
 		let asset_server = world.get_resource::<AssetServer>().unwrap();
 		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());

--- a/examples/bundles.rs
+++ b/examples/bundles.rs
@@ -35,7 +35,7 @@ impl ProtoComponent for SpriteBundleDef {
 	/// Please keep in mind the ordering here. Rust's borrow checker still applies here: we can't have
 	/// both a mutable and immutable access to world at the same time. Therefore, you will need to break
 	/// your world access into chunks, getting whatever handles or data you need along the way
-	fn prepare(&self, world: &mut World, prototype: &Box<dyn Prototypical>, data: &mut ProtoData) {
+	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
 		// === Load Handles === //
 		let asset_server = world.get_resource::<AssetServer>().unwrap();
 		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());


### PR DESCRIPTION
The changes from #11 broke some examples when the signature for `ProtoComponent` changed. This PR fixes the examples.