### PR TITLE
Remove rustfmt

### DIFF
--- a/bevy_proto_derive/src/attributes.rs
+++ b/bevy_proto_derive/src/attributes.rs
@@ -7,62 +7,62 @@ use crate::constants::{INTO_IDENT, WITH_IDENT};
 
 /// ProtoComponent attributes applied on structs
 pub(crate) enum ProtoCompAttr {
-	/// Captures the `#[proto_comp(into = "ActualComponent")]` attribute
-	///
-	/// This is used to specify a separate Component that this marked struct will be cloned into.
-	///
-	/// Generates the following code:
-	/// ```rust
-	/// let component: ActualComponent = self.clone().into();
-	/// commands.insert(component);
-	/// ```
-	Into(Ident),
-	/// Captures the `#[proto_comp(with = "my_function")]` attribute
-	///
-	/// This is used to specify a custom function with which custom Components will be creatde and/or inserted.
-	/// This is essentially identical to just simply implementing `ProtoComponent` yourself.
-	///
-	/// Generates the following code:
-	/// ```rust
-	/// my_function(self, commands, asset_server);
-	/// ```
-	With(Ident),
+    /// Captures the `#[proto_comp(into = "ActualComponent")]` attribute
+    ///
+    /// This is used to specify a separate Component that this marked struct will be cloned into.
+    ///
+    /// Generates the following code:
+    /// ```rust
+    /// let component: ActualComponent = self.clone().into();
+    /// commands.insert(component);
+    /// ```
+    Into(Ident),
+    /// Captures the `#[proto_comp(with = "my_function")]` attribute
+    ///
+    /// This is used to specify a custom function with which custom Components will be creatde and/or inserted.
+    /// This is essentially identical to just simply implementing `ProtoComponent` yourself.
+    ///
+    /// Generates the following code:
+    /// ```rust
+    /// my_function(self, commands, asset_server);
+    /// ```
+    With(Ident),
 }
 
 impl Parse for ProtoCompAttr {
-	fn parse(input: ParseStream) -> Result<Self> {
-		let path: Path = input.parse()?;
-		let _: Token![=] = input.parse()?;
-		let item: LitStr = input.parse()?;
-		let ident = format_ident!("{}", item.value());
+    fn parse(input: ParseStream) -> Result<Self> {
+        let path: Path = input.parse()?;
+        let _: Token![=] = input.parse()?;
+        let item: LitStr = input.parse()?;
+        let ident = format_ident!("{}", item.value());
 
-		if path == WITH_IDENT {
-			Ok(Self::With(ident))
-		} else if path == INTO_IDENT {
-			Ok(Self::Into(ident))
-		} else {
-			Err(Error::new(Span::call_site(), "Unexpected path"))
-		}
-	}
+        if path == WITH_IDENT {
+            Ok(Self::With(ident))
+        } else if path == INTO_IDENT {
+            Ok(Self::Into(ident))
+        } else {
+            Err(Error::new(Span::call_site(), "Unexpected path"))
+        }
+    }
 }
 
 impl ToTokens for ProtoCompAttr {
-	fn to_tokens(&self, tokens: &mut TokenStream) {
-		match self {
-			Self::Into(ident) => {
-				let into_ident = quote! {
-					let cloned = self.clone();
-					let component: #ident = cloned.into();
-					commands.insert(component);
-				};
-				into_ident.to_tokens(tokens);
-			}
-			Self::With(ident) => {
-				let with_ident = quote! {
-					#ident(self, commands, asset_server);
-				};
-				with_ident.to_tokens(tokens);
-			}
-		}
-	}
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Into(ident) => {
+                let into_ident = quote! {
+                    let cloned = self.clone();
+                    let component: #ident = cloned.into();
+                    commands.insert(component);
+                };
+                into_ident.to_tokens(tokens);
+            }
+            Self::With(ident) => {
+                let with_ident = quote! {
+                    #ident(self, commands, asset_server);
+                };
+                with_ident.to_tokens(tokens);
+            }
+        }
+    }
 }

--- a/bevy_proto_derive/src/constants.rs
+++ b/bevy_proto_derive/src/constants.rs
@@ -3,15 +3,15 @@
 pub(crate) struct Symbol(&'static str);
 
 impl<'a> PartialEq<Symbol> for &'a syn::Path {
-	fn eq(&self, ident: &Symbol) -> bool {
-		self.is_ident(ident.0)
-	}
+    fn eq(&self, ident: &Symbol) -> bool {
+        self.is_ident(ident.0)
+    }
 }
 
 impl PartialEq<Symbol> for syn::Path {
-	fn eq(&self, ident: &Symbol) -> bool {
-		self.is_ident(ident.0)
-	}
+    fn eq(&self, ident: &Symbol) -> bool {
+        self.is_ident(ident.0)
+    }
 }
 
 pub(crate) const WITH_IDENT: Symbol = Symbol("with");

--- a/bevy_proto_derive/src/lib.rs
+++ b/bevy_proto_derive/src/lib.rs
@@ -41,49 +41,49 @@ mod constants;
 /// ```
 #[proc_macro_derive(ProtoComponent, attributes(proto_comp))]
 pub fn proto_comp_derive(input: TokenStream) -> TokenStream {
-	let DeriveInput {
-		ident, data, attrs, ..
-	} = parse_macro_input!(input);
+    let DeriveInput {
+        ident, data, attrs, ..
+    } = parse_macro_input!(input);
 
-	let mut generator = None;
-	for attr in attrs {
-		let struct_attr: Result<ProtoCompAttr> = attr.parse_args();
-		if let Ok(struct_attr) = struct_attr {
-			generator = Some(quote! { #struct_attr });
-			break;
-		}
-	}
+    let mut generator = None;
+    for attr in attrs {
+        let struct_attr: Result<ProtoCompAttr> = attr.parse_args();
+        if let Ok(struct_attr) = struct_attr {
+            generator = Some(quote! { #struct_attr });
+            break;
+        }
+    }
 
-	let generator = if let Some(generator) = generator {
-		generator
-	} else {
-		match data {
-			Data::Struct(..) | Data::Enum(..) => {
-				quote! {
-					let component = self.clone();
-					commands.insert(component);
-				}
-			}
-			_ => syn::Error::new(
-				Span::call_site(),
-				"ProtoComponent can only be applied on struct types",
-			)
-			.to_compile_error(),
-		}
-	};
+    let generator = if let Some(generator) = generator {
+        generator
+    } else {
+        match data {
+            Data::Struct(..) | Data::Enum(..) => {
+                quote! {
+                    let component = self.clone();
+                    commands.insert(component);
+                }
+            }
+            _ => syn::Error::new(
+                Span::call_site(),
+                "ProtoComponent can only be applied on struct types",
+            )
+            .to_compile_error(),
+        }
+    };
 
-	let output = quote! {
-		#[typetag::serde]
-		impl bevy_proto::prelude::ProtoComponent for #ident {
-			fn insert_self(
-				&self,
-				commands: &mut bevy_proto::prelude::ProtoCommands,
-				asset_server: &bevy::prelude::Res<bevy::prelude::AssetServer>,
-			) {
-				#generator;
-			}
-		}
-	};
+    let output = quote! {
+        #[typetag::serde]
+        impl bevy_proto::prelude::ProtoComponent for #ident {
+            fn insert_self(
+                &self,
+                commands: &mut bevy_proto::prelude::ProtoCommands,
+                asset_server: &bevy::prelude::Res<bevy::prelude::AssetServer>,
+            ) {
+                #generator;
+            }
+        }
+    };
 
-	output.into()
+    output.into()
 }

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -23,14 +23,14 @@ struct Emoji(String);
 #[derive(Clone, Serialize, Deserialize, ProtoComponent)]
 #[proto_comp(into = "Emoji")]
 struct EmojiDef {
-	emoji: String,
+    emoji: String,
 }
 
 /// Make sure you impl `From<T>`!
 impl From<EmojiDef> for Emoji {
-	fn from(def: EmojiDef) -> Self {
-		Self(def.emoji)
-	}
+    fn from(def: EmojiDef) -> Self {
+        Self(def.emoji)
+    }
 }
 
 /// Alternatively, you might want or have a function that performs the spawn logic that should
@@ -38,17 +38,17 @@ impl From<EmojiDef> for Emoji {
 ///
 /// Say we have a trait that allows its implementors to return an `Emoji` struct.
 trait AsEmoji {
-	fn as_emoji(&self) -> Emoji;
+    fn as_emoji(&self) -> Emoji;
 }
 
 /// We can create a function that takes any `ProtoComponent` that implements `AsEmoji` and inserts
 /// an `Emoji` component.
 fn create_emoji<T: AsEmoji + ProtoComponent>(
-	component: &T,
-	commands: &mut ProtoCommands,
-	_asset_server: &Res<AssetServer>,
+    component: &T,
+    commands: &mut ProtoCommands,
+    _asset_server: &Res<AssetServer>,
 ) {
-	commands.insert(component.as_emoji());
+    commands.insert(component.as_emoji());
 }
 
 /// Then we can use the `#[proto_comp(with = "my_function")]` attribute. This works exactly
@@ -56,16 +56,16 @@ fn create_emoji<T: AsEmoji + ProtoComponent>(
 #[derive(Clone, Serialize, Deserialize, ProtoComponent)]
 #[proto_comp(with = "create_emoji")]
 enum Mood {
-	Normal,
-	Silly,
+    Normal,
+    Silly,
 }
 impl AsEmoji for Mood {
-	fn as_emoji(&self) -> Emoji {
-		match self {
-			Self::Normal => Emoji(String::from("😶")),
-			Self::Silly => Emoji(String::from("🤪")),
-		}
-	}
+    fn as_emoji(&self) -> Emoji {
+        match self {
+            Self::Normal => Emoji(String::from("😶")),
+            Self::Silly => Emoji(String::from("🤪")),
+        }
+    }
 }
 
 /// Notice that we only had to define the function once even though we're using it across multiple
@@ -73,40 +73,40 @@ impl AsEmoji for Mood {
 #[derive(Clone, Serialize, Deserialize, ProtoComponent)]
 #[proto_comp(with = "create_emoji")]
 enum Face {
-	Normal,
-	Frowning,
+    Normal,
+    Frowning,
 }
 impl AsEmoji for Face {
-	fn as_emoji(&self) -> Emoji {
-		match self {
-			Self::Normal => Emoji(String::from("😶")),
-			Self::Frowning => Emoji(String::from("😠")),
-		}
-	}
+    fn as_emoji(&self) -> Emoji {
+        match self {
+            Self::Normal => Emoji(String::from("😶")),
+            Self::Frowning => Emoji(String::from("😠")),
+        }
+    }
 }
 
 fn spawn_emojis(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>) {
-	let proto = data.get_prototype("Happy").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Sad").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Silly").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Angry").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Happy").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Sad").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Silly").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Angry").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
 }
 
 fn print_emojies(query: Query<&Emoji, Added<Emoji>>) {
-	for emoji in query.iter() {
-		println!("{}", emoji.0);
-	}
+    for emoji in query.iter() {
+        println!("{}", emoji.0);
+    }
 }
 
 fn main() {
-	App::new()
-		.add_plugins(DefaultPlugins)
-		.add_plugin(ProtoPlugin::default())
-		.add_startup_system(spawn_emojis)
-		.add_system(print_emojies)
-		.run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ProtoPlugin::default())
+        .add_startup_system(spawn_emojis)
+        .add_system(print_emojies)
+        .run();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,7 +9,7 @@ use bevy_proto::prelude::*;
 /// It must impl/derive Serialize, Clone, and Deserialize from serde in order to compile
 #[derive(Clone, Serialize, Deserialize, Component)]
 struct Person {
-	pub name: String,
+    pub name: String,
 }
 
 /// This is where we implement the [`ProtoComponent`] trait.
@@ -17,17 +17,17 @@ struct Person {
 /// Note that we must apply the `#[typetag::serde]` attribute
 #[typetag::serde]
 impl ProtoComponent for Person {
-	fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
-		/// Here, we create the component we're going to insert.
-		/// This can really be any valid Bevy component type, but we'll
-		/// use `Person` since it's so simple
-		let component = Self {
-			name: self.name.clone(),
-		};
+    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
+        /// Here, we create the component we're going to insert.
+        /// This can really be any valid Bevy component type, but we'll
+        /// use `Person` since it's so simple
+        let component = Self {
+            name: self.name.clone(),
+        };
 
-		// Attach the component(s) to the entity
-		commands.insert(component);
-	}
+        // Attach the component(s) to the entity
+        commands.insert(component);
+    }
 }
 
 /// For simple types, deriving [`ProtoComponent`] can be used to automatically
@@ -42,53 +42,53 @@ impl ProtoComponent for Person {
 /// ```
 #[derive(Copy, Clone, Serialize, Deserialize, ProtoComponent, Component)]
 struct Ordered {
-	pub order: i32,
+    pub order: i32,
 }
 
 /// Spawn in the person.
 ///
 /// This system also demonstrates the minimum requirements for using the prototype system
 fn spawn_person(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>) {
-	/// Here, we attempt to get our prototype by name.
-	/// We'll raise an exception if it's not found, just so we can fail fast.
-	/// In reality, you'll likely want to handle this prototype not existing.
-	let proto = data.get_prototype("Person Test 1").expect("Should exist!");
+    /// Here, we attempt to get our prototype by name.
+    /// We'll raise an exception if it's not found, just so we can fail fast.
+    /// In reality, you'll likely want to handle this prototype not existing.
+    let proto = data.get_prototype("Person Test 1").expect("Should exist!");
 
-	// Spawn in the prototype!
-	proto.spawn(&mut commands, &data, &asset_server);
+    // Spawn in the prototype!
+    proto.spawn(&mut commands, &data, &asset_server);
 
-	// Spawn it again!
-	proto.spawn(&mut commands, &data, &asset_server);
+    // Spawn it again!
+    proto.spawn(&mut commands, &data, &asset_server);
 
-	// Insert on an existing entity!
-	let entity = commands.spawn().id();
-	let entity_cmds = commands.entity(entity);
-	proto.insert(entity_cmds, &data, &asset_server);
+    // Insert on an existing entity!
+    let entity = commands.spawn().id();
+    let entity_cmds = commands.entity(entity);
+    proto.insert(entity_cmds, &data, &asset_server);
 
-	// Spawn in others!
-	for i in 2..=3 {
-		data.get_prototype(format!("Person Test {}", i).as_str())
-			.unwrap()
-			.spawn(&mut commands, &data, &asset_server);
-	}
+    // Spawn in others!
+    for i in 2..=3 {
+        data.get_prototype(format!("Person Test {}", i).as_str())
+            .unwrap()
+            .spawn(&mut commands, &data, &asset_server);
+    }
 }
 
 /// A system to test our spawner. This makes each entity introduce itself when spawned in
 fn introduce(query: Query<(&Person, &Ordered), Added<Person>>) {
-	for (person, ordered) in query.iter() {
-		println!("{}. Hello! My name is {}", ordered.order, person.name);
-	}
+    for (person, ordered) in query.iter() {
+        println!("{}. Hello! My name is {}", ordered.order, person.name);
+    }
 }
 
 fn main() {
-	App::new()
-		.add_plugins(DefaultPlugins)
-		// This plugin should come AFTER any others that it might rely on
-		// In this case, we need access to what's added by [`DefaultPlugins`]
-		// so we place this line after that one
-		.add_plugin(ProtoPlugin::default())
-		// Add our spawner system (this one only runs once at startup)
-		.add_startup_system(spawn_person)
-		.add_system(introduce)
-		.run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // This plugin should come AFTER any others that it might rely on
+        // In this case, we need access to what's added by [`DefaultPlugins`]
+        // so we place this line after that one
+        .add_plugin(ProtoPlugin::default())
+        // Add our spawner system (this one only runs once at startup)
+        .add_startup_system(spawn_person)
+        .add_system(introduce)
+        .run();
 }

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -99,7 +99,7 @@ impl ProtoComponent for SpriteBundleDef {
 		commands.insert_bundle(my_bundle);
 	}
 
-	fn prepare(&self, world: &mut World, prototype: &Box<dyn Prototypical>, data: &mut ProtoData) {
+	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
 		// === Load Handles === //
 		let asset_server = world.get_resource::<AssetServer>().unwrap();
 		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -9,68 +9,68 @@ const BATCH_SIZE: u128 = 5_000;
 const BATCH_COUNT: u128 = ENTITY_COUNT / BATCH_SIZE;
 
 fn spawn_sprites_proto(
-	mut commands: Commands,
-	data: Res<ProtoData>,
-	asset_server: Res<AssetServer>,
+    mut commands: Commands,
+    data: Res<ProtoData>,
+    asset_server: Res<AssetServer>,
 ) {
-	println!("Spawning via Prototype:");
-	let mut total: u128 = 0;
-	let mut before = Instant::now();
-	let proto = data.get_prototype("Sprite Test").expect("Should exist!");
+    println!("Spawning via Prototype:");
+    let mut total: u128 = 0;
+    let mut before = Instant::now();
+    let proto = data.get_prototype("Sprite Test").expect("Should exist!");
 
-	for _ in 0..BATCH_COUNT {
-		for _ in 0..BATCH_SIZE {
-			proto.spawn(&mut commands, &data, &asset_server);
-		}
-		println!("Prototype Batch: {:.2?}", before.elapsed());
-		total += before.elapsed().as_millis();
-		before = Instant::now();
-	}
+    for _ in 0..BATCH_COUNT {
+        for _ in 0..BATCH_SIZE {
+            proto.spawn(&mut commands, &data, &asset_server);
+        }
+        println!("Prototype Batch: {:.2?}", before.elapsed());
+        total += before.elapsed().as_millis();
+        before = Instant::now();
+    }
 
-	println!(
-		"Prototypes: {}ms for {} (avg. batch {}ms)",
-		total,
-		ENTITY_COUNT,
-		total / BATCH_COUNT
-	);
+    println!(
+        "Prototypes: {}ms for {} (avg. batch {}ms)",
+        total,
+        ENTITY_COUNT,
+        total / BATCH_COUNT
+    );
 }
 
 fn spawn_sprites_programmatic(mut commands: Commands, asset_server: Res<AssetServer>) {
-	println!("Spawning Programmatically:");
-	let mut total: u128 = 0;
-	let mut before = Instant::now();
+    println!("Spawning Programmatically:");
+    let mut total: u128 = 0;
+    let mut before = Instant::now();
 
-	for _ in 0..BATCH_COUNT {
-		for _ in 0..BATCH_SIZE {
-			commands.spawn_bundle(SpriteBundle {
-				texture: asset_server.load("textures/sprite.png"),
-				..Default::default()
-			});
-		}
-		println!("Programmatic Batch: {:.2?}", before.elapsed());
-		total += before.elapsed().as_millis();
-		before = Instant::now();
-	}
+    for _ in 0..BATCH_COUNT {
+        for _ in 0..BATCH_SIZE {
+            commands.spawn_bundle(SpriteBundle {
+                texture: asset_server.load("textures/sprite.png"),
+                ..Default::default()
+            });
+        }
+        println!("Programmatic Batch: {:.2?}", before.elapsed());
+        total += before.elapsed().as_millis();
+        before = Instant::now();
+    }
 
-	println!(
-		"Programmatic: {}ms for {} (avg. batch {}ms)",
-		total,
-		ENTITY_COUNT,
-		total / BATCH_COUNT
-	);
+    println!(
+        "Programmatic: {}ms for {} (avg. batch {}ms)",
+        total,
+        ENTITY_COUNT,
+        total / BATCH_COUNT
+    );
 }
 
 fn main() {
-	println!(
-		"Entity Count: {} | Batch Size: {}",
-		ENTITY_COUNT, BATCH_SIZE
-	);
-	App::new()
-		.add_plugins(DefaultPlugins)
-		.add_plugin(ProtoPlugin::default())
-		.add_startup_system(spawn_sprites_proto.label("prototype"))
-		.add_startup_system(spawn_sprites_programmatic.after("prototype"))
-		.run();
+    println!(
+        "Entity Count: {} | Batch Size: {}",
+        ENTITY_COUNT, BATCH_SIZE
+    );
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ProtoPlugin::default())
+        .add_startup_system(spawn_sprites_proto.label("prototype"))
+        .add_startup_system(spawn_sprites_programmatic.after("prototype"))
+        .run();
 }
 
 /// The code below is covered in the `bundles` example. It's an implementation
@@ -78,33 +78,33 @@ fn main() {
 
 #[derive(Serialize, Deserialize, Component)]
 struct SpriteBundleDef {
-	pub texture_path: HandlePath,
+    pub texture_path: HandlePath,
 }
 
 #[typetag::serde]
 impl ProtoComponent for SpriteBundleDef {
-	fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
-		// === Get Prepared Assets === //
-		let texture: Handle<Image> = commands
-			.get_handle(self, &self.texture_path)
-			.expect("Expected Image handle to have been created");
+    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
+        // === Get Prepared Assets === //
+        let texture: Handle<Image> = commands
+            .get_handle(self, &self.texture_path)
+            .expect("Expected Image handle to have been created");
 
-		// === Generate Bundle === //
-		let my_bundle = SpriteBundle {
-			texture,
-			..Default::default()
-		};
+        // === Generate Bundle === //
+        let my_bundle = SpriteBundle {
+            texture,
+            ..Default::default()
+        };
 
-		// === Insert Generated Bundle === //
-		commands.insert_bundle(my_bundle);
-	}
+        // === Insert Generated Bundle === //
+        commands.insert_bundle(my_bundle);
+    }
 
-	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
-		// === Load Handles === //
-		let asset_server = world.get_resource::<AssetServer>().unwrap();
-		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());
+    fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
+        // === Load Handles === //
+        let asset_server = world.get_resource::<AssetServer>().unwrap();
+        let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());
 
-		// === Save Handles === //
-		data.insert_handle(prototype, self, &self.texture_path, texture);
-	}
+        // === Save Handles === //
+        data.insert_handle(prototype, self, &self.texture_path, texture);
+    }
 }

--- a/examples/bundles.rs
+++ b/examples/bundles.rs
@@ -35,7 +35,7 @@ impl ProtoComponent for SpriteBundleDef {
 	/// Please keep in mind the ordering here. Rust's borrow checker still applies here: we can't have
 	/// both a mutable and immutable access to world at the same time. Therefore, you will need to break
 	/// your world access into chunks, getting whatever handles or data you need along the way
-	fn prepare(&self, world: &mut World, prototype: &Box<dyn Prototypical>, data: &mut ProtoData) {
+	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
 		// === Load Handles === //
 		let asset_server = world.get_resource::<AssetServer>().unwrap();
 		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());

--- a/examples/bundles.rs
+++ b/examples/bundles.rs
@@ -7,64 +7,64 @@ use bevy_proto::prelude::*;
 
 #[derive(Serialize, Deserialize, Component)]
 struct SpriteBundleDef {
-	pub texture_path: HandlePath,
+    pub texture_path: HandlePath,
 }
 
 #[typetag::serde]
 impl ProtoComponent for SpriteBundleDef {
-	fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
-		// === Get Prepared Assets === //
-		let texture: Handle<Image> = commands
-			.get_handle(self, &self.texture_path)
-			.expect("Expected Image handle to have been created");
+    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
+        // === Get Prepared Assets === //
+        let texture: Handle<Image> = commands
+            .get_handle(self, &self.texture_path)
+            .expect("Expected Image handle to have been created");
 
-		// === Generate Bundle === //
-		let my_bundle = SpriteBundle {
-			texture,
-			..Default::default()
-		};
+        // === Generate Bundle === //
+        let my_bundle = SpriteBundle {
+            texture,
+            ..Default::default()
+        };
 
-		// === Insert Generated Bundle === //
-		commands.insert_bundle(my_bundle);
-	}
+        // === Insert Generated Bundle === //
+        commands.insert_bundle(my_bundle);
+    }
 
-	/// Here, we prepare any assets that this bundle/component might need that require additional setup.
-	/// Since we want to load a texture AND add it to the ColorMaterial asset store, we need to
-	/// do so in this prepare method.
-	///
-	/// Please keep in mind the ordering here. Rust's borrow checker still applies here: we can't have
-	/// both a mutable and immutable access to world at the same time. Therefore, you will need to break
-	/// your world access into chunks, getting whatever handles or data you need along the way
-	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
-		// === Load Handles === //
-		let asset_server = world.get_resource::<AssetServer>().unwrap();
-		let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());
+    /// Here, we prepare any assets that this bundle/component might need that require additional setup.
+    /// Since we want to load a texture AND add it to the ColorMaterial asset store, we need to
+    /// do so in this prepare method.
+    ///
+    /// Please keep in mind the ordering here. Rust's borrow checker still applies here: we can't have
+    /// both a mutable and immutable access to world at the same time. Therefore, you will need to break
+    /// your world access into chunks, getting whatever handles or data you need along the way
+    fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {
+        // === Load Handles === //
+        let asset_server = world.get_resource::<AssetServer>().unwrap();
+        let texture: Handle<Image> = asset_server.load(self.texture_path.as_str());
 
-		// === Save Handles === //
-		data.insert_handle(prototype, self, &self.texture_path, texture);
-	}
+        // === Save Handles === //
+        data.insert_handle(prototype, self, &self.texture_path, texture);
+    }
 }
 
 fn spawn_sprite(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>) {
-	commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 
-	/// Here, we attempt to get our prototype by name.
-	/// We'll raise an exception if it's not found, just so we can fail fast.
-	/// In reality, you'll likely want to handle this prototype not existing.
-	let proto = data.get_prototype("Sprite Test").expect("Should exist!");
+    /// Here, we attempt to get our prototype by name.
+    /// We'll raise an exception if it's not found, just so we can fail fast.
+    /// In reality, you'll likely want to handle this prototype not existing.
+    let proto = data.get_prototype("Sprite Test").expect("Should exist!");
 
-	// Spawn in the prototype!
-	proto.spawn(&mut commands, &data, &asset_server);
+    // Spawn in the prototype!
+    proto.spawn(&mut commands, &data, &asset_server);
 }
 
 fn main() {
-	App::new()
-		.add_plugins(DefaultPlugins)
-		// This plugin should come AFTER any others that it might rely on
-		// In this case, we need access to what's added by [`DefaultPlugins`]
-		// so we place this line after that one
-		.add_plugin(ProtoPlugin::default())
-		// Add our spawner system (this one only runs once at startup)
-		.add_startup_system(spawn_sprite)
-		.run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // This plugin should come AFTER any others that it might rely on
+        // In this case, we need access to what's added by [`DefaultPlugins`]
+        // so we place this line after that one
+        .add_plugin(ProtoPlugin::default())
+        // Add our spawner system (this one only runs once at startup)
+        .add_startup_system(spawn_sprite)
+        .run();
 }

--- a/examples/templates.rs
+++ b/examples/templates.rs
@@ -26,14 +26,14 @@ struct Occupation(OccupationType);
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 enum OccupationType {
-	Unemployed,
-	Miner,
-	Shopkeeper,
+    Unemployed,
+    Miner,
+    Shopkeeper,
 }
 
 #[derive(Clone, Serialize, Deserialize, ProtoComponent, Component)]
 struct Health {
-	max: u16,
+    max: u16,
 }
 
 #[derive(Clone, Serialize, Deserialize, ProtoComponent, Component)]
@@ -41,36 +41,36 @@ struct Named(String);
 
 /// Spawn in the NPC
 fn spawn_npc(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>) {
-	let proto = data.get_prototype("Alice").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Bob").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Urist").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
-	let proto = data.get_prototype("Mystery").expect("Should exist!");
-	proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Alice").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Bob").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Urist").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
+    let proto = data.get_prototype("Mystery").expect("Should exist!");
+    proto.spawn(&mut commands, &data, &asset_server);
 }
 
 /// Handle the NPC spawning
 fn on_spawn(query: Query<(&Health, &Occupation, Option<&Named>), Added<NPC>>) {
-	for (health, occupation, name) in query.iter() {
-		let name = if let Some(name) = name {
-			format!("'{}'", name.0)
-		} else {
-			String::from("<UNKNOWN>")
-		};
-		println!(
-			"NPC {} => MaxHP: {} | Occupation: {:?}",
-			name, health.max, occupation.0
-		);
-	}
+    for (health, occupation, name) in query.iter() {
+        let name = if let Some(name) = name {
+            format!("'{}'", name.0)
+        } else {
+            String::from("<UNKNOWN>")
+        };
+        println!(
+            "NPC {} => MaxHP: {} | Occupation: {:?}",
+            name, health.max, occupation.0
+        );
+    }
 }
 
 fn main() {
-	App::new()
-		.add_plugins(DefaultPlugins)
-		.add_plugin(ProtoPlugin::with_dir("assets/prototypes/templates"))
-		.add_startup_system(spawn_npc)
-		.add_system(on_spawn)
-		.run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ProtoPlugin::with_dir("assets/prototypes/templates"))
+        .add_startup_system(spawn_npc)
+        .add_system(on_spawn)
+        .run();
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,0 @@
-chain_width = 60
-editon = "2018"
-fn_args_layout = "Tall"
-hard_tabs = true
-match_block_trailing_comma = true
-newline_style = "Unix"
-tab_spaces = 4
-use_field_init_shorthand = true

--- a/src/components.rs
+++ b/src/components.rs
@@ -6,7 +6,7 @@ use crate::prototype::Prototypical;
 /// A trait that allows components to be used within [`Prototypical`] structs
 #[typetag::serde(tag = "type", content = "value")]
 pub trait ProtoComponent: Send + Sync + 'static {
-	fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>);
-	#[allow(unused_variables)]
-	fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {}
+    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>);
+    #[allow(unused_variables)]
+    fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {}
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -19,433 +19,433 @@ use crate::{components::ProtoComponent, prototype::Prototypical, utils::handle_c
 pub struct HandlePath(pub String);
 
 impl Deref for HandlePath {
-	type Target = String;
+    type Target = String;
 
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 type UuidHandleMap = HashMap<Uuid, HandleUntyped>;
 
 /// A resource containing data for all prototypes that need data stored
 pub struct ProtoData {
-	/// Maps Prototype Name -> Component Type -> HandlePath -> Asset Type -> HandleUntyped
-	handles: HashMap<
-		String, // Prototype Name
-		HashMap<
-			TypeId, // Component Type
-			HashMap<
-				String, // Handle Path
-				UuidHandleMap,
-			>,
-		>,
-	>,
-	prototypes: HashMap<String, Box<dyn Prototypical>>,
+    /// Maps Prototype Name -> Component Type -> HandlePath -> Asset Type -> HandleUntyped
+    handles: HashMap<
+        String, // Prototype Name
+        HashMap<
+            TypeId, // Component Type
+            HashMap<
+                String, // Handle Path
+                UuidHandleMap,
+            >,
+        >,
+    >,
+    prototypes: HashMap<String, Box<dyn Prototypical>>,
 }
 
 impl ProtoData {
-	pub fn empty() -> Self {
-		Self {
-			handles: HashMap::default(),
-			prototypes: HashMap::default(),
-		}
-	}
+    pub fn empty() -> Self {
+        Self {
+            handles: HashMap::default(),
+            prototypes: HashMap::default(),
+        }
+    }
 
-	/// Get a loaded prototype with the given name
-	///
-	/// # Arguments
-	///
-	/// * `name`: The name of the prototype
-	///
-	/// returns: Option<&Prototype>
-	pub fn get_prototype(&self, name: &str) -> Option<&dyn Prototypical> {
-		self.prototypes.get(name).map(|b| b.as_ref())
-	}
+    /// Get a loaded prototype with the given name
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: The name of the prototype
+    ///
+    /// returns: Option<&Prototype>
+    pub fn get_prototype(&self, name: &str) -> Option<&dyn Prototypical> {
+        self.prototypes.get(name).map(|b| b.as_ref())
+    }
 
-	/// Store a handle
-	///
-	/// # Arguments
-	///
-	/// * `protoytpe`: The Prototype this handle belongs to
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	/// * `handle`: The handle
-	///
-	/// returns: ()
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy::prelude::*;
-	/// use bevy_proto::{HandlePath, ProtoData, Prototype, PrototypeDataContainer};
-	///
-	/// struct MyComponent {
-	///     texture_path: HandlePath
-	/// }
-	///
-	/// // impl ProtoComponent for MyComponent { ... }
-	///
-	/// fn some_loader(asset_server: Res<AssetServer>, mut data: ResMut<ProtoData>) {
-	///     let comp = MyComponent {
-	///         texture_path: HandlePath(String::from("path/to/texture.png"))
-	///     };
-	///     let proto = Prototype {
-	///         name: String::from("My Prototype"),
-	///         templates: Vec::default(),
-	///         components: vec![Box::new(comp)]
-	///     };
-	///
-	///     let handle: Handle<Image> =  asset_server.load(comp.texture_path.0.as_str());
-	///
-	///     data.insert_handle(&proto, &comp, &comp.texture_path, handle);
-	/// }
-	/// ```
-	pub fn insert_handle<T: Asset>(
-		&mut self,
-		protoytpe: &dyn Prototypical,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-		handle: Handle<T>,
-	) {
-		let proto_map = self
-			.handles
-			.entry(protoytpe.name().to_string())
-			.or_insert_with(HashMap::default);
-		let comp_map = proto_map
-			.entry(component.type_id())
-			.or_insert_with(HashMap::default);
-		let path_map = comp_map
-			.entry(path.to_string())
-			.or_insert_with(HashMap::default);
-		path_map.insert(T::TYPE_UUID, handle.clone_untyped());
-	}
+    /// Store a handle
+    ///
+    /// # Arguments
+    ///
+    /// * `protoytpe`: The Prototype this handle belongs to
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    /// * `handle`: The handle
+    ///
+    /// returns: ()
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_proto::{HandlePath, ProtoData, Prototype, PrototypeDataContainer};
+    ///
+    /// struct MyComponent {
+    ///     texture_path: HandlePath
+    /// }
+    ///
+    /// // impl ProtoComponent for MyComponent { ... }
+    ///
+    /// fn some_loader(asset_server: Res<AssetServer>, mut data: ResMut<ProtoData>) {
+    ///     let comp = MyComponent {
+    ///         texture_path: HandlePath(String::from("path/to/texture.png"))
+    ///     };
+    ///     let proto = Prototype {
+    ///         name: String::from("My Prototype"),
+    ///         templates: Vec::default(),
+    ///         components: vec![Box::new(comp)]
+    ///     };
+    ///
+    ///     let handle: Handle<Image> =  asset_server.load(comp.texture_path.0.as_str());
+    ///
+    ///     data.insert_handle(&proto, &comp, &comp.texture_path, handle);
+    /// }
+    /// ```
+    pub fn insert_handle<T: Asset>(
+        &mut self,
+        protoytpe: &dyn Prototypical,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+        handle: Handle<T>,
+    ) {
+        let proto_map = self
+            .handles
+            .entry(protoytpe.name().to_string())
+            .or_insert_with(HashMap::default);
+        let comp_map = proto_map
+            .entry(component.type_id())
+            .or_insert_with(HashMap::default);
+        let path_map = comp_map
+            .entry(path.to_string())
+            .or_insert_with(HashMap::default);
+        path_map.insert(T::TYPE_UUID, handle.clone_untyped());
+    }
 
-	/// Get a cloned handle
-	///
-	/// # Arguments
-	///
-	/// * `protoytpe`: The Prototype this handle belongs to
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	///
-	/// returns: Option<Handle<T>>
-	pub fn get_handle<T: Asset>(
-		&self,
-		protoytpe: &dyn Prototypical,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-	) -> Option<Handle<T>> {
-		let handle = self.get_untyped_handle(protoytpe, component, path, T::TYPE_UUID)?;
-		Some(handle.clone().typed::<T>())
-	}
+    /// Get a cloned handle
+    ///
+    /// # Arguments
+    ///
+    /// * `protoytpe`: The Prototype this handle belongs to
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    ///
+    /// returns: Option<Handle<T>>
+    pub fn get_handle<T: Asset>(
+        &self,
+        protoytpe: &dyn Prototypical,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+    ) -> Option<Handle<T>> {
+        let handle = self.get_untyped_handle(protoytpe, component, path, T::TYPE_UUID)?;
+        Some(handle.clone().typed::<T>())
+    }
 
-	/// Get a weakly cloned handle
-	///
-	/// # Arguments
-	///
-	/// * `protoytpe`: The Prototype this handle belongs to
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	///
-	/// returns: Option<Handle<T>>
-	pub fn get_handle_weak<T: Asset>(
-		&self,
-		protoytpe: &dyn Prototypical,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-	) -> Option<Handle<T>> {
-		let handle = self.get_untyped_handle(protoytpe, component, path, T::TYPE_UUID)?;
-		Some(handle.clone_weak().typed::<T>())
-	}
+    /// Get a weakly cloned handle
+    ///
+    /// # Arguments
+    ///
+    /// * `protoytpe`: The Prototype this handle belongs to
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    ///
+    /// returns: Option<Handle<T>>
+    pub fn get_handle_weak<T: Asset>(
+        &self,
+        protoytpe: &dyn Prototypical,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+    ) -> Option<Handle<T>> {
+        let handle = self.get_untyped_handle(protoytpe, component, path, T::TYPE_UUID)?;
+        Some(handle.clone_weak().typed::<T>())
+    }
 
-	/// Get a untyped handle reference
-	///
-	/// # Arguments
-	///
-	/// * `protoytpe`: The Prototype this handle belongs to
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	/// * `asset_type`: The asset type
-	///
-	/// returns: Option<&HandleUntyped>
-	pub fn get_untyped_handle(
-		&self,
-		protoytpe: &dyn Prototypical,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-		asset_type: Uuid,
-	) -> Option<&HandleUntyped> {
-		let proto_map = self.handles.get(protoytpe.name())?;
-		let comp_map = proto_map.get(&component.type_id())?;
-		let path_map = comp_map.get(path.as_str())?;
-		path_map.get(&asset_type)
-	}
+    /// Get a untyped handle reference
+    ///
+    /// # Arguments
+    ///
+    /// * `protoytpe`: The Prototype this handle belongs to
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    /// * `asset_type`: The asset type
+    ///
+    /// returns: Option<&HandleUntyped>
+    pub fn get_untyped_handle(
+        &self,
+        protoytpe: &dyn Prototypical,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+        asset_type: Uuid,
+    ) -> Option<&HandleUntyped> {
+        let proto_map = self.handles.get(protoytpe.name())?;
+        let comp_map = proto_map.get(&component.type_id())?;
+        let path_map = comp_map.get(path.as_str())?;
+        path_map.get(&asset_type)
+    }
 
-	/// Create a [`ProtoCommands`] object for the given prototype
-	///
-	/// # Arguments
-	///
-	/// * `prototype`: The associated prototype
-	/// * `commands`: The [`EntityCommands`]
-	///
-	/// returns: ProtoCommands
-	pub fn get_commands<'w, 's, 'a, 'p>(
-		&'p self,
-		prototype: &'p dyn Prototypical,
-		commands: EntityCommands<'w, 's, 'a>,
-	) -> ProtoCommands<'w, 's, 'a, 'p> {
-		ProtoCommands {
-			commands,
-			prototype,
-			data: self,
-		}
-	}
+    /// Create a [`ProtoCommands`] object for the given prototype
+    ///
+    /// # Arguments
+    ///
+    /// * `prototype`: The associated prototype
+    /// * `commands`: The [`EntityCommands`]
+    ///
+    /// returns: ProtoCommands
+    pub fn get_commands<'w, 's, 'a, 'p>(
+        &'p self,
+        prototype: &'p dyn Prototypical,
+        commands: EntityCommands<'w, 's, 'a>,
+    ) -> ProtoCommands<'w, 's, 'a, 'p> {
+        ProtoCommands {
+            commands,
+            prototype,
+            data: self,
+        }
+    }
 
-	/// Get an iterator over all prototypes
-	pub fn iter(&self) -> impl Iterator<Item = &Box<dyn Prototypical>> {
-		self.prototypes.values()
-	}
+    /// Get an iterator over all prototypes
+    pub fn iter(&self) -> impl Iterator<Item = &Box<dyn Prototypical>> {
+        self.prototypes.values()
+    }
 
-	/// Get a mutable iterator over all prototypes
-	pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<dyn Prototypical>> {
-		self.prototypes.values_mut()
-	}
+    /// Get a mutable iterator over all prototypes
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<dyn Prototypical>> {
+        self.prototypes.values_mut()
+    }
 }
 
 impl FromWorld for ProtoData {
-	fn from_world(world: &mut World) -> Self {
-		let mut myself = Self {
-			handles: Default::default(),
-			prototypes: HashMap::default(),
-		};
+    fn from_world(world: &mut World) -> Self {
+        let mut myself = Self {
+            handles: Default::default(),
+            prototypes: HashMap::default(),
+        };
 
-		let options = world
-			.get_resource::<ProtoDataOptions>()
-			.expect("Expected options for ProtoData")
-			.clone();
+        let options = world
+            .get_resource::<ProtoDataOptions>()
+            .expect("Expected options for ProtoData")
+            .clone();
 
-		for directory in options.directories {
-			process_path(
-				world,
-				&options.extensions,
-				options.deserializer.as_ref(),
-				&mut myself,
-				&directory,
-				options.recursive_loading,
-			);
-		}
+        for directory in options.directories {
+            process_path(
+                world,
+                &options.extensions,
+                options.deserializer.as_ref(),
+                &mut myself,
+                &directory,
+                options.recursive_loading,
+            );
+        }
 
-		#[cfg(feature = "analysis")]
-		analyze_deps(&myself);
+        #[cfg(feature = "analysis")]
+        analyze_deps(&myself);
 
-		myself
-	}
+        myself
+    }
 }
 
 /// Helper function to populate our ProtoData.
 fn process_path(
-	world: &mut World,
-	extensions: &Option<Vec<&str>>,
-	deserializer: &(dyn ProtoDeserializer + Send + Sync),
-	myself: &mut ProtoData,
-	directory: &str,
-	recursive: bool,
+    world: &mut World,
+    extensions: &Option<Vec<&str>>,
+    deserializer: &(dyn ProtoDeserializer + Send + Sync),
+    myself: &mut ProtoData,
+    directory: &str,
+    recursive: bool,
 ) {
-	if let Ok(dir) = std::fs::read_dir(directory) {
-		for file_info in dir {
-			if file_info.is_err() {
-				continue;
-			}
-			let file_info = file_info.unwrap();
+    if let Ok(dir) = std::fs::read_dir(directory) {
+        for file_info in dir {
+            if file_info.is_err() {
+                continue;
+            }
+            let file_info = file_info.unwrap();
 
-			let path = file_info.path();
+            let path = file_info.path();
 
-			if recursive && path.is_dir() {
-				process_path(
-					world,
-					extensions,
-					deserializer,
-					myself,
-					&path.to_str().unwrap().to_string(),
-					recursive,
-				);
-			}
+            if recursive && path.is_dir() {
+                process_path(
+                    world,
+                    extensions,
+                    deserializer,
+                    myself,
+                    &path.to_str().unwrap().to_string(),
+                    recursive,
+                );
+            }
 
-			if let Some(filters) = &extensions {
-				if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-					if !filters.iter().any(|filter| filter == &ext) {
-						continue;
-					}
-				}
-			}
+            if let Some(filters) = &extensions {
+                if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+                    if !filters.iter().any(|filter| filter == &ext) {
+                        continue;
+                    }
+                }
+            }
 
-			if let Ok(data) = std::fs::read_to_string(path) {
-				if let Some(proto) = deserializer.deserialize(&data) {
-					for component in proto.iter_components() {
-						component.prepare(world, proto.as_ref(), myself);
-					}
+            if let Ok(data) = std::fs::read_to_string(path) {
+                if let Some(proto) = deserializer.deserialize(&data) {
+                    for component in proto.iter_components() {
+                        component.prepare(world, proto.as_ref(), myself);
+                    }
 
-					myself.prototypes.insert(proto.name().to_string(), proto);
-				}
-			}
-		}
-	}
+                    myself.prototypes.insert(proto.name().to_string(), proto);
+                }
+            }
+        }
+    }
 }
 
 /// Performs some analysis on the given [`ProtoData`] resource
 fn analyze_deps(data: &ProtoData) {
-	// === Perform Analysis === //
-	for proto in data.iter() {
-		check_for_cycles(proto.as_ref(), data, &mut IndexSet::default());
-	}
+    // === Perform Analysis === //
+    for proto in data.iter() {
+        check_for_cycles(proto.as_ref(), data, &mut IndexSet::default());
+    }
 
-	// === Analysis Functions === //
-	fn check_for_cycles<'a>(
-		proto: &'a dyn Prototypical,
-		data: &'a ProtoData,
-		traversed: &mut IndexSet<&'a str>,
-	) {
-		traversed.insert(proto.name());
+    // === Analysis Functions === //
+    fn check_for_cycles<'a>(
+        proto: &'a dyn Prototypical,
+        data: &'a ProtoData,
+        traversed: &mut IndexSet<&'a str>,
+    ) {
+        traversed.insert(proto.name());
 
-		for template in proto.templates_rev() {
-			if traversed.contains(template.as_str()) {
-				// ! --- Found Circular Dependency --- ! //
-				handle_cycle!(template, traversed);
+        for template in proto.templates_rev() {
+            if traversed.contains(template.as_str()) {
+                // ! --- Found Circular Dependency --- ! //
+                handle_cycle!(template, traversed);
 
-				continue;
-			}
+                continue;
+            }
 
-			if let Some(parent) = data.get_prototype(template) {
-				// --- Check Template --- //
-				check_for_cycles(parent, data, traversed);
-			}
-		}
-	}
+            if let Some(parent) = data.get_prototype(template) {
+                // --- Check Template --- //
+                check_for_cycles(parent, data, traversed);
+            }
+        }
+    }
 }
 
 /// A wrapper around [`EntityCommands`] and [`ProtoData`] for a specified prototype.
 /// This allows [`ProtoData`] to be accessed with the underlying prototype directly,
 /// and grants direct access to the [`EntityCommands`] that spawned that prototype in.
 pub struct ProtoCommands<'w, 's, 'a, 'p> {
-	/// The associated [`EntityCommands`]
-	commands: EntityCommands<'w, 's, 'a>,
-	/// The associated prototype
-	prototype: &'p dyn Prototypical,
-	/// The [`ProtoData`] resource
-	data: &'p ProtoData,
+    /// The associated [`EntityCommands`]
+    commands: EntityCommands<'w, 's, 'a>,
+    /// The associated prototype
+    prototype: &'p dyn Prototypical,
+    /// The [`ProtoData`] resource
+    data: &'p ProtoData,
 }
 
 impl<'w, 's, 'a, 'p> ProtoCommands<'w, 's, 'a, 'p> {
-	/// Get raw access to [`EntityCommands`]
-	pub fn raw_commands(&'p mut self) -> &'p mut EntityCommands<'w, 's, 'a> {
-		&mut self.commands
-	}
-	/// Get the associated prototype
-	pub fn protoype(&self) -> &dyn Prototypical {
-		self.prototype
-	}
+    /// Get raw access to [`EntityCommands`]
+    pub fn raw_commands(&'p mut self) -> &'p mut EntityCommands<'w, 's, 'a> {
+        &mut self.commands
+    }
+    /// Get the associated prototype
+    pub fn protoype(&self) -> &dyn Prototypical {
+        self.prototype
+    }
 
-	/// Get raw access to the underlying [`ProtoData`] resource
-	pub fn raw_data(&self) -> &ProtoData {
-		self.data
-	}
+    /// Get raw access to the underlying [`ProtoData`] resource
+    pub fn raw_data(&self) -> &ProtoData {
+        self.data
+    }
 
-	/// Get a cloned handle
-	///
-	/// # Arguments
-	///
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	///
-	/// returns: Option<Handle<T>>
-	pub fn get_handle<T: Asset>(
-		&self,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-	) -> Option<Handle<T>> {
-		self.data.get_handle(self.prototype, component, path)
-	}
+    /// Get a cloned handle
+    ///
+    /// # Arguments
+    ///
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    ///
+    /// returns: Option<Handle<T>>
+    pub fn get_handle<T: Asset>(
+        &self,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+    ) -> Option<Handle<T>> {
+        self.data.get_handle(self.prototype, component, path)
+    }
 
-	/// Get a weakly cloned handle
-	///
-	/// # Arguments
-	///
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	///
-	/// returns: Option<Handle<T>>
-	pub fn get_handle_weak<T: Asset>(
-		&self,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-	) -> Option<Handle<T>> {
-		self.data.get_handle_weak(self.prototype, component, path)
-	}
+    /// Get a weakly cloned handle
+    ///
+    /// # Arguments
+    ///
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    ///
+    /// returns: Option<Handle<T>>
+    pub fn get_handle_weak<T: Asset>(
+        &self,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+    ) -> Option<Handle<T>> {
+        self.data.get_handle_weak(self.prototype, component, path)
+    }
 
-	/// Get a untyped handle reference
-	///
-	/// # Arguments
-	///
-	/// * `component`: The ProtoComponent this handle belongs to
-	/// * `path`: The handle's path
-	/// * `asset_type`: The asset type
-	///
-	/// returns: Option<&HandleUntyped>
-	pub fn get_untyped_handle(
-		&self,
-		component: &dyn ProtoComponent,
-		path: &HandlePath,
-		asset_type: Uuid,
-	) -> Option<&HandleUntyped> {
-		self.data
-			.get_untyped_handle(self.prototype, component, path, asset_type)
-	}
+    /// Get a untyped handle reference
+    ///
+    /// # Arguments
+    ///
+    /// * `component`: The ProtoComponent this handle belongs to
+    /// * `path`: The handle's path
+    /// * `asset_type`: The asset type
+    ///
+    /// returns: Option<&HandleUntyped>
+    pub fn get_untyped_handle(
+        &self,
+        component: &dyn ProtoComponent,
+        path: &HandlePath,
+        asset_type: Uuid,
+    ) -> Option<&HandleUntyped> {
+        self.data
+            .get_untyped_handle(self.prototype, component, path, asset_type)
+    }
 }
 
 impl<'w, 's, 'a, 'p> From<ProtoCommands<'w, 's, 'a, 'p>> for EntityCommands<'w, 's, 'a> {
-	fn from(cmds: ProtoCommands<'w, 's, 'a, 'p>) -> Self {
-		cmds.commands
-	}
+    fn from(cmds: ProtoCommands<'w, 's, 'a, 'p>) -> Self {
+        cmds.commands
+    }
 }
 
 impl<'w, 's, 'a, 'p> Deref for ProtoCommands<'w, 's, 'a, 'p> {
-	type Target = EntityCommands<'w, 's, 'a>;
+    type Target = EntityCommands<'w, 's, 'a>;
 
-	fn deref(&self) -> &Self::Target {
-		&self.commands
-	}
+    fn deref(&self) -> &Self::Target {
+        &self.commands
+    }
 }
 
 impl<'w, 's, 'a, 'p> DerefMut for ProtoCommands<'w, 's, 'a, 'p> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.commands
-	}
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.commands
+    }
 }
 
 pub trait ProtoDeserializer: DynClone {
-	/// Deserializes file input (as a string) into a [`Prototypical`] object
-	///
-	/// # Arguments
-	///
-	/// * `data`: The file data as a string
-	///
-	/// returns: Option<Box<dyn Prototypical, Global>>
-	///
-	/// # Examples
-	///
-	/// ```
-	/// // The default implementation:
-	/// use bevy_proto::{Prototype, Prototypical};
-	/// fn example_deserialize(data: &str) -> Option<Box<dyn Prototypical>> {
-	///     if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
-	///         Some(Box::new(value))
-	///     } else {
-	///         None
-	///    }
-	/// }
-	/// ```
-	fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>>;
+    /// Deserializes file input (as a string) into a [`Prototypical`] object
+    ///
+    /// # Arguments
+    ///
+    /// * `data`: The file data as a string
+    ///
+    /// returns: Option<Box<dyn Prototypical, Global>>
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // The default implementation:
+    /// use bevy_proto::{Prototype, Prototypical};
+    /// fn example_deserialize(data: &str) -> Option<Box<dyn Prototypical>> {
+    ///     if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
+    ///         Some(Box::new(value))
+    ///     } else {
+    ///         None
+    ///    }
+    /// }
+    /// ```
+    fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>>;
 }
 
 dyn_clone::clone_trait_object!(ProtoDeserializer);
@@ -453,42 +453,42 @@ dyn_clone::clone_trait_object!(ProtoDeserializer);
 /// Options for controlling how prototype data is handled
 #[derive(Clone)]
 pub struct ProtoDataOptions {
-	/// Directories containing prototype data
-	pub directories: Vec<String>,
-	/// Whether to resursively load extension files from the specified top-level directories.
-	///
-	/// # Examples
-	///
-	/// Example that recursively loads all yaml files from the assets/prototypes directory.
-	///
-	/// ```
-	/// use bevy_proto::ProtoDataOptions;
-	///
-	/// let opts = ProtoDataOptions {
-	///     directories: vec![String::from("assets/prototypes")],
-	///     recursive_loading: true,
-	///     extensions: Some(vec!["yaml"]),
-	///     ..Default::default()
-	/// };
-	/// ```
-	pub recursive_loading: bool,
-	/// A custom deserializer for prototypes
-	pub deserializer: Box<dyn ProtoDeserializer + Send + Sync>,
-	/// A collection of extensions to filter the directories by. These do __not__
-	/// have a dot ('.') prepended to them.
-	///
-	/// A value of None allows all files to be read.
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy_proto::ProtoDataOptions;
-	///
-	/// let opts = ProtoDataOptions {
-	///     // Only allow .yaml or .json files
-	///     extensions: Some(vec!["yaml", "json"]),
-	///     ..Default::default()
-	/// };
-	/// ```
-	pub extensions: Option<Vec<&'static str>>,
+    /// Directories containing prototype data
+    pub directories: Vec<String>,
+    /// Whether to resursively load extension files from the specified top-level directories.
+    ///
+    /// # Examples
+    ///
+    /// Example that recursively loads all yaml files from the assets/prototypes directory.
+    ///
+    /// ```
+    /// use bevy_proto::ProtoDataOptions;
+    ///
+    /// let opts = ProtoDataOptions {
+    ///     directories: vec![String::from("assets/prototypes")],
+    ///     recursive_loading: true,
+    ///     extensions: Some(vec!["yaml"]),
+    ///     ..Default::default()
+    /// };
+    /// ```
+    pub recursive_loading: bool,
+    /// A custom deserializer for prototypes
+    pub deserializer: Box<dyn ProtoDeserializer + Send + Sync>,
+    /// A collection of extensions to filter the directories by. These do __not__
+    /// have a dot ('.') prepended to them.
+    ///
+    /// A value of None allows all files to be read.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_proto::ProtoDataOptions;
+    ///
+    /// let opts = ProtoDataOptions {
+    ///     // Only allow .yaml or .json files
+    ///     extensions: Some(vec!["yaml", "json"]),
+    ///     ..Default::default()
+    /// };
+    /// ```
+    pub extensions: Option<Vec<&'static str>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ pub mod prototype;
 mod utils;
 
 pub mod prelude {
-	pub use bevy_proto_derive::*;
+    pub use bevy_proto_derive::*;
 
-	pub use super::components::*;
-	pub use super::data::*;
-	pub use super::plugin::*;
-	pub use super::prototype::{Prototype, Prototypical};
+    pub use super::components::*;
+    pub use super::data::*;
+    pub use super::plugin::*;
+    pub use super::prototype::{Prototype, Prototypical};
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,156 +1,156 @@
 use bevy::app::{App, Plugin};
 
 use crate::{
-	data::{ProtoData, ProtoDataOptions, ProtoDeserializer},
-	prototype::{Prototype, Prototypical},
+    data::{ProtoData, ProtoDataOptions, ProtoDeserializer},
+    prototype::{Prototype, Prototypical},
 };
 
 #[derive(Default)]
 pub struct ProtoPlugin {
-	pub options: Option<ProtoDataOptions>,
+    pub options: Option<ProtoDataOptions>,
 }
 
 impl ProtoPlugin {
-	/// Specify the directory containing the prototype files
-	///
-	/// # Arguments
-	///
-	/// * `dir`: The directory path, relative to the project root
-	///
-	/// returns: ProtoPlugin
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy_proto::ProtoPlugin;
-	///
-	/// let plugin = ProtoPlugin::with_dir("assets/config");
-	/// ```
-	pub fn with_dir(dir: &str) -> Self {
-		Self {
-			options: Some(ProtoDataOptions {
-				directories: vec![dir.to_string()],
-				recursive_loading: false,
-				deserializer: Box::new(DefaultProtoDeserializer),
-				extensions: Some(vec!["yaml", "json"]),
-			}),
-		}
-	}
+    /// Specify the directory containing the prototype files
+    ///
+    /// # Arguments
+    ///
+    /// * `dir`: The directory path, relative to the project root
+    ///
+    /// returns: ProtoPlugin
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_proto::ProtoPlugin;
+    ///
+    /// let plugin = ProtoPlugin::with_dir("assets/config");
+    /// ```
+    pub fn with_dir(dir: &str) -> Self {
+        Self {
+            options: Some(ProtoDataOptions {
+                directories: vec![dir.to_string()],
+                recursive_loading: false,
+                deserializer: Box::new(DefaultProtoDeserializer),
+                extensions: Some(vec!["yaml", "json"]),
+            }),
+        }
+    }
 
-	/// Same as [with_dir] but recursively loads prototype files.
-	///
-	/// # Arguments
-	///
-	/// * `dir`: The directory path, relative to the project root
-	///
-	/// returns: ProtoPlugin
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy_proto::ProtoPlugin;
-	///
-	/// let plugin = ProtoPlugin::with_dir_recursive("assets/config");
-	/// ```
-	pub fn with_dir_recursive(dir: &str) -> Self {
-		Self {
-			options: Some(ProtoDataOptions {
-				directories: vec![dir.to_string()],
-				recursive_loading: true,
-				deserializer: Box::new(DefaultProtoDeserializer),
-				extensions: Some(vec!["yaml", "json"]),
-			}),
-		}
-	}
+    /// Same as [with_dir] but recursively loads prototype files.
+    ///
+    /// # Arguments
+    ///
+    /// * `dir`: The directory path, relative to the project root
+    ///
+    /// returns: ProtoPlugin
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_proto::ProtoPlugin;
+    ///
+    /// let plugin = ProtoPlugin::with_dir_recursive("assets/config");
+    /// ```
+    pub fn with_dir_recursive(dir: &str) -> Self {
+        Self {
+            options: Some(ProtoDataOptions {
+                directories: vec![dir.to_string()],
+                recursive_loading: true,
+                deserializer: Box::new(DefaultProtoDeserializer),
+                extensions: Some(vec!["yaml", "json"]),
+            }),
+        }
+    }
 
-	/// Specify a set of directories containing the prototype files
-	///
-	/// # Arguments
-	///
-	/// * `dirs`: The directory paths, relative to the project root
-	///
-	/// returns: ProtoPlugin
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy_proto::ProtoPlugin;
-	///
-	/// let plugin = ProtoPlugin::with_dirs(vec![
-	///   String::from("assets/config"),
-	///   String::from("assets/mods"),
-	/// ]);
-	/// ```
-	pub fn with_dirs(dirs: Vec<String>) -> Self {
-		Self {
-			options: Some(ProtoDataOptions {
-				directories: dirs,
-				recursive_loading: false,
-				deserializer: Box::new(DefaultProtoDeserializer),
-				extensions: Some(vec!["yaml", "json"]),
-			}),
-		}
-	}
+    /// Specify a set of directories containing the prototype files
+    ///
+    /// # Arguments
+    ///
+    /// * `dirs`: The directory paths, relative to the project root
+    ///
+    /// returns: ProtoPlugin
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_proto::ProtoPlugin;
+    ///
+    /// let plugin = ProtoPlugin::with_dirs(vec![
+    ///   String::from("assets/config"),
+    ///   String::from("assets/mods"),
+    /// ]);
+    /// ```
+    pub fn with_dirs(dirs: Vec<String>) -> Self {
+        Self {
+            options: Some(ProtoDataOptions {
+                directories: dirs,
+                recursive_loading: false,
+                deserializer: Box::new(DefaultProtoDeserializer),
+                extensions: Some(vec!["yaml", "json"]),
+            }),
+        }
+    }
 
-	/// Same as [with_dirs] but recursively loads prototype files.
-	///
-	/// # Arguments
-	///
-	/// * `dirs`: The directory paths, relative to the project root
-	///
-	/// returns: ProtoPlugin
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy_proto::ProtoPlugin;
-	///
-	/// let plugin = ProtoPlugin::with_dirs(vec![
-	///   String::from("assets/config"),
-	///   String::from("assets/mods"),
-	/// ]);
-	/// ```
-	pub fn with_dirs_recursive(dirs: Vec<String>) -> Self {
-		Self {
-			options: Some(ProtoDataOptions {
-				directories: dirs,
-				recursive_loading: true,
-				deserializer: Box::new(DefaultProtoDeserializer),
-				extensions: Some(vec!["yaml", "json"]),
-			}),
-		}
-	}
+    /// Same as [with_dirs] but recursively loads prototype files.
+    ///
+    /// # Arguments
+    ///
+    /// * `dirs`: The directory paths, relative to the project root
+    ///
+    /// returns: ProtoPlugin
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_proto::ProtoPlugin;
+    ///
+    /// let plugin = ProtoPlugin::with_dirs(vec![
+    ///   String::from("assets/config"),
+    ///   String::from("assets/mods"),
+    /// ]);
+    /// ```
+    pub fn with_dirs_recursive(dirs: Vec<String>) -> Self {
+        Self {
+            options: Some(ProtoDataOptions {
+                directories: dirs,
+                recursive_loading: true,
+                deserializer: Box::new(DefaultProtoDeserializer),
+                extensions: Some(vec!["yaml", "json"]),
+            }),
+        }
+    }
 }
 
 impl Plugin for ProtoPlugin {
-	fn build(&self, app: &mut App) {
-		if let Some(opts) = &self.options {
-			// Insert custom prototype options
-			app.insert_resource(opts.clone());
-		} else {
-			// Insert default options
-			app.insert_resource(ProtoDataOptions {
-				directories: vec![String::from("assets/prototypes")],
-				recursive_loading: false,
-				deserializer: Box::new(DefaultProtoDeserializer),
-				extensions: Some(vec!["yaml", "json"]),
-			});
-		}
+    fn build(&self, app: &mut App) {
+        if let Some(opts) = &self.options {
+            // Insert custom prototype options
+            app.insert_resource(opts.clone());
+        } else {
+            // Insert default options
+            app.insert_resource(ProtoDataOptions {
+                directories: vec![String::from("assets/prototypes")],
+                recursive_loading: false,
+                deserializer: Box::new(DefaultProtoDeserializer),
+                extensions: Some(vec!["yaml", "json"]),
+            });
+        }
 
-		// Initialize prototypes
-		app.init_resource::<ProtoData>();
-	}
+        // Initialize prototypes
+        app.init_resource::<ProtoData>();
+    }
 }
 
 #[derive(Clone)]
 struct DefaultProtoDeserializer;
 
 impl ProtoDeserializer for DefaultProtoDeserializer {
-	fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>> {
-		if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
-			Some(Box::new(value))
-		} else {
-			None
-		}
-	}
+    fn deserialize(&self, data: &str) -> Option<Box<dyn Prototypical>> {
+        if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
+            Some(Box::new(value))
+        } else {
+            None
+        }
+    }
 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -7,237 +7,237 @@ use bevy::ecs::system::EntityCommands;
 use bevy::prelude::{AssetServer, Res};
 use indexmap::IndexSet;
 use serde::{
-	de::{self, Error, SeqAccess, Visitor},
-	Deserialize, Deserializer, Serialize,
+    de::{self, Error, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
 };
 
 use crate::{
-	components::ProtoComponent, data::ProtoCommands, data::ProtoData, utils::handle_cycle,
+    components::ProtoComponent, data::ProtoCommands, data::ProtoData, utils::handle_cycle,
 };
 
 /// Allows access to a prototype's name and components so that it can be spawned in
 pub trait Prototypical: 'static + Send + Sync {
-	/// The name of the prototype
-	///
-	/// This should be unique amongst all prototypes in the world
-	fn name(&self) -> &str;
+    /// The name of the prototype
+    ///
+    /// This should be unique amongst all prototypes in the world
+    fn name(&self) -> &str;
 
-	/// The names of the parent templates (if any)
-	fn templates(&self) -> &[String] {
-		&[]
-	}
+    /// The names of the parent templates (if any)
+    fn templates(&self) -> &[String] {
+        &[]
+    }
 
-	/// The names of the parent templates (if any) in reverse order
-	fn templates_rev(&self) -> Rev<Iter<'_, String>> {
-		self.templates().iter().rev()
-	}
+    /// The names of the parent templates (if any) in reverse order
+    fn templates_rev(&self) -> Rev<Iter<'_, String>> {
+        self.templates().iter().rev()
+    }
 
-	/// Returns an iterator of [`ProtoComponent`] objects
-	fn iter_components(&self) -> Iter<'_, Box<dyn ProtoComponent>>;
+    /// Returns an iterator of [`ProtoComponent`] objects
+    fn iter_components(&self) -> Iter<'_, Box<dyn ProtoComponent>>;
 
-	/// Creates the [`ProtoCommands`] object used for modifying the given entity
-	///
-	/// # Arguments
-	///
-	/// * `entity`: The entity commands
-	/// * `data`: The prototype data in this world
-	///
-	/// returns: ProtoCommands
-	///
-	fn create_commands<'w, 's, 'a, 'p>(
-		&'p self,
-		entity: EntityCommands<'w, 's, 'a>,
-		data: &'p Res<ProtoData>,
-	) -> ProtoCommands<'w, 's, 'a, 'p>;
+    /// Creates the [`ProtoCommands`] object used for modifying the given entity
+    ///
+    /// # Arguments
+    ///
+    /// * `entity`: The entity commands
+    /// * `data`: The prototype data in this world
+    ///
+    /// returns: ProtoCommands
+    ///
+    fn create_commands<'w, 's, 'a, 'p>(
+        &'p self,
+        entity: EntityCommands<'w, 's, 'a>,
+        data: &'p Res<ProtoData>,
+    ) -> ProtoCommands<'w, 's, 'a, 'p>;
 
-	/// Spawns an entity with this prototype's component structure
-	///
-	/// # Arguments
-	///
-	/// * `commands`: The world `Commands`
-	/// * `data`: The prototype data in this world
-	/// * `asset_server`: The asset server
-	///
-	/// returns: EntityCommands
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy::prelude::*;
-	/// use bevy_proto::prelude::{ProtoData, Prototype, Prototypical};
-	///
-	/// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>) {
-	///     let proto: Prototype = serde_yaml::from_str(r#"
-	///     name: My Prototype
-	///     components:
-	///       - type: SomeMarkerComponent
-	///       - type: SomeComponent
-	///         value:
-	///           - speed: 10.0
-	///     "#).unwrap();
-	///
-	///     let entity = proto.spawn(&mut commands, &data, &asset_server).id();
-	///
-	///     // ...
-	/// }
-	///
-	/// ```
-	fn spawn<'w, 's, 'a, 'p>(
-		&'p self,
-		commands: &'a mut Commands<'w, 's>,
-		data: &Res<ProtoData>,
-		asset_server: &Res<AssetServer>,
-	) -> EntityCommands<'w, 's, 'a> {
-		let entity = commands.spawn();
-		self.insert(entity, data, asset_server)
-	}
+    /// Spawns an entity with this prototype's component structure
+    ///
+    /// # Arguments
+    ///
+    /// * `commands`: The world `Commands`
+    /// * `data`: The prototype data in this world
+    /// * `asset_server`: The asset server
+    ///
+    /// returns: EntityCommands
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_proto::prelude::{ProtoData, Prototype, Prototypical};
+    ///
+    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>) {
+    ///     let proto: Prototype = serde_yaml::from_str(r#"
+    ///     name: My Prototype
+    ///     components:
+    ///       - type: SomeMarkerComponent
+    ///       - type: SomeComponent
+    ///         value:
+    ///           - speed: 10.0
+    ///     "#).unwrap();
+    ///
+    ///     let entity = proto.spawn(&mut commands, &data, &asset_server).id();
+    ///
+    ///     // ...
+    /// }
+    ///
+    /// ```
+    fn spawn<'w, 's, 'a, 'p>(
+        &'p self,
+        commands: &'a mut Commands<'w, 's>,
+        data: &Res<ProtoData>,
+        asset_server: &Res<AssetServer>,
+    ) -> EntityCommands<'w, 's, 'a> {
+        let entity = commands.spawn();
+        self.insert(entity, data, asset_server)
+    }
 
-	/// Inserts this prototype's component structure to the given entity
-	///
-	/// __Note:__ This _will_ override existing components of the same type.
-	///
-	/// # Arguments
-	///
-	/// * `entity`: The `EntityCommands` for a given entity
-	/// * `data`: The prototype data in this world
-	/// * `asset_server`: The asset server
-	///
-	/// returns: EntityCommands
-	///
-	/// # Examples
-	///
-	/// ```
-	/// use bevy::prelude::*;
-	/// use bevy_proto::prelude::{ProtoData, Prototype, Prototypical};
-	///
-	/// #[derive(Component, Default)]
-	/// struct Player(pub Entity);
-	///
-	/// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>, player: Query<&Player>) {
-	///     let proto: Prototype = serde_yaml::from_str(r#"
-	///     name: My Prototype
-	///     components:
-	///       - type: SomeMarkerComponent
-	///       - type: SomeComponent
-	///         value:
-	///           - speed: 10.0
-	///     "#).unwrap();
-	///
-	///     // Get the EntityCommands for the player entity
-	///     let entity = commands.entity(player.single().0);
-	///
-	///     // Insert the new components
-	///     let entity = proto.insert(entity, &data, &asset_server).id();
-	///
-	///     // ...
-	/// }
-	///
-	/// ```
-	fn insert<'w, 's, 'a, 'p>(
-		&'p self,
-		entity: EntityCommands<'w, 's, 'a>,
-		data: &Res<ProtoData>,
-		asset_server: &Res<AssetServer>,
-	) -> EntityCommands<'w, 's, 'a> {
-		let mut proto_commands = self.create_commands(entity, data);
+    /// Inserts this prototype's component structure to the given entity
+    ///
+    /// __Note:__ This _will_ override existing components of the same type.
+    ///
+    /// # Arguments
+    ///
+    /// * `entity`: The `EntityCommands` for a given entity
+    /// * `data`: The prototype data in this world
+    /// * `asset_server`: The asset server
+    ///
+    /// returns: EntityCommands
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_proto::prelude::{ProtoData, Prototype, Prototypical};
+    ///
+    /// #[derive(Component, Default)]
+    /// struct Player(pub Entity);
+    ///
+    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>, player: Query<&Player>) {
+    ///     let proto: Prototype = serde_yaml::from_str(r#"
+    ///     name: My Prototype
+    ///     components:
+    ///       - type: SomeMarkerComponent
+    ///       - type: SomeComponent
+    ///         value:
+    ///           - speed: 10.0
+    ///     "#).unwrap();
+    ///
+    ///     // Get the EntityCommands for the player entity
+    ///     let entity = commands.entity(player.single().0);
+    ///
+    ///     // Insert the new components
+    ///     let entity = proto.insert(entity, &data, &asset_server).id();
+    ///
+    ///     // ...
+    /// }
+    ///
+    /// ```
+    fn insert<'w, 's, 'a, 'p>(
+        &'p self,
+        entity: EntityCommands<'w, 's, 'a>,
+        data: &Res<ProtoData>,
+        asset_server: &Res<AssetServer>,
+    ) -> EntityCommands<'w, 's, 'a> {
+        let mut proto_commands = self.create_commands(entity, data);
 
-		spawn_internal(
-			self.name(),
-			self.templates().iter().rev(),
-			self.iter_components(),
-			&mut proto_commands,
-			data,
-			asset_server,
-			&mut IndexSet::default(),
-		);
+        spawn_internal(
+            self.name(),
+            self.templates().iter().rev(),
+            self.iter_components(),
+            &mut proto_commands,
+            data,
+            asset_server,
+            &mut IndexSet::default(),
+        );
 
-		proto_commands.into()
-	}
+        proto_commands.into()
+    }
 }
 
 /// Internal method used for recursing up the template hierarchy and spawning components
 /// from the top to the bottom
 fn spawn_internal<'a>(
-	name: &'a str,
-	templates: Rev<Iter<'a, String>>,
-	components: Iter<'a, Box<dyn ProtoComponent>>,
-	proto_commands: &mut ProtoCommands,
-	data: &'a Res<ProtoData>,
-	asset_server: &Res<AssetServer>,
-	traversed: &mut IndexSet<&'a str>,
+    name: &'a str,
+    templates: Rev<Iter<'a, String>>,
+    components: Iter<'a, Box<dyn ProtoComponent>>,
+    proto_commands: &mut ProtoCommands,
+    data: &'a Res<ProtoData>,
+    asset_server: &Res<AssetServer>,
+    traversed: &mut IndexSet<&'a str>,
 ) {
-	// We insert first on the off chance that someone made a prototype its own template...
-	traversed.insert(name);
+    // We insert first on the off chance that someone made a prototype its own template...
+    traversed.insert(name);
 
-	for template in templates {
-		if traversed.contains(template.as_str()) {
-			// ! === Found Circular Dependency === ! //
-			handle_cycle!(
-				template,
-				traversed,
-				"For now, the rest of the spawn has been skipped."
-			);
+    for template in templates {
+        if traversed.contains(template.as_str()) {
+            // ! === Found Circular Dependency === ! //
+            handle_cycle!(
+                template,
+                traversed,
+                "For now, the rest of the spawn has been skipped."
+            );
 
-			continue;
-		}
+            continue;
+        }
 
-		// === Spawn Template === //
-		if let Some(parent) = data.get_prototype(template) {
-			spawn_internal(
-				parent.name(),
-				parent.templates_rev(),
-				parent.iter_components(),
-				proto_commands,
-				data,
-				asset_server,
-				traversed,
-			);
-		}
-	}
+        // === Spawn Template === //
+        if let Some(parent) = data.get_prototype(template) {
+            spawn_internal(
+                parent.name(),
+                parent.templates_rev(),
+                parent.iter_components(),
+                proto_commands,
+                data,
+                asset_server,
+                traversed,
+            );
+        }
+    }
 
-	// === Spawn Self === //
-	for component in components {
-		component.insert_self(proto_commands, asset_server);
-	}
+    // === Spawn Self === //
+    for component in components {
+        component.insert_self(proto_commands, asset_server);
+    }
 }
 
 /// The default prototype object, providing the basics for the prototype system
 #[derive(Serialize, Deserialize)]
 pub struct Prototype {
-	/// The name of this prototype
-	pub name: String,
-	/// The names of this prototype's templates (if any)
-	///
-	/// See [`deserialize_templates_list`], for how these names are deserialized.
-	#[serde(default)]
-	#[serde(alias = "template")]
-	#[serde(deserialize_with = "deserialize_templates_list")]
-	pub templates: Vec<String>,
-	/// The components belonging to this prototype
-	#[serde(default)]
-	pub components: Vec<Box<dyn ProtoComponent>>,
+    /// The name of this prototype
+    pub name: String,
+    /// The names of this prototype's templates (if any)
+    ///
+    /// See [`deserialize_templates_list`], for how these names are deserialized.
+    #[serde(default)]
+    #[serde(alias = "template")]
+    #[serde(deserialize_with = "deserialize_templates_list")]
+    pub templates: Vec<String>,
+    /// The components belonging to this prototype
+    #[serde(default)]
+    pub components: Vec<Box<dyn ProtoComponent>>,
 }
 
 impl Prototypical for Prototype {
-	fn name(&self) -> &str {
-		&self.name
-	}
+    fn name(&self) -> &str {
+        &self.name
+    }
 
-	fn templates(&self) -> &[String] {
-		&self.templates
-	}
+    fn templates(&self) -> &[String] {
+        &self.templates
+    }
 
-	fn iter_components(&self) -> Iter<'_, Box<dyn ProtoComponent>> {
-		self.components.iter()
-	}
+    fn iter_components(&self) -> Iter<'_, Box<dyn ProtoComponent>> {
+        self.components.iter()
+    }
 
-	fn create_commands<'w, 's, 'a, 'p>(
-		&'p self,
-		entity: EntityCommands<'w, 's, 'a>,
-		data: &'p Res<ProtoData>,
-	) -> ProtoCommands<'w, 's, 'a, 'p> {
-		data.get_commands(self, entity)
-	}
+    fn create_commands<'w, 's, 'a, 'p>(
+        &'p self,
+        entity: EntityCommands<'w, 's, 'a>,
+        data: &'p Res<ProtoData>,
+    ) -> ProtoCommands<'w, 's, 'a, 'p> {
+        data.get_commands(self, entity)
+    }
 }
 
 /// A function used to deserialize a list of templates
@@ -261,33 +261,33 @@ impl Prototypical for Prototype {
 ///   > ```
 pub fn deserialize_templates_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
-	D: Deserializer<'de>,
+    D: Deserializer<'de>,
 {
-	struct TemplatesList;
+    struct TemplatesList;
 
-	impl<'de> Visitor<'de> for TemplatesList {
-		type Value = Vec<String>;
+    impl<'de> Visitor<'de> for TemplatesList {
+        type Value = Vec<String>;
 
-		fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-			formatter.write_str("string or vec")
-		}
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("string or vec")
+        }
 
-		fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-		where
-			E: Error,
-		{
-			// Split string by commas
-			// Allowing for: "A, B, C" to become [A, B, C]
-			Ok(v.split(',').map(|s| s.trim().to_string()).collect())
-		}
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            // Split string by commas
+            // Allowing for: "A, B, C" to become [A, B, C]
+            Ok(v.split(',').map(|s| s.trim().to_string()).collect())
+        }
 
-		fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
-		where
-			A: SeqAccess<'de>,
-		{
-			Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
-		}
-	}
+        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
+        }
+    }
 
-	deserializer.deserialize_any(TemplatesList)
+    deserializer.deserialize_any(TemplatesList)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,11 +25,11 @@ use std::ops::Add;
 /// // Output: 'A' -> 'B' -> 'C' -> 'B'
 /// ```
 pub(crate) fn make_cycle_tree(template_name: &str, traversed: &IndexSet<&str>) -> String {
-	traversed
-		.iter()
-		.map(|n| format!("'{}' -> ", n))
-		.collect::<String>()
-		.add(&format!("'{}'", template_name))
+    traversed
+        .iter()
+        .map(|n| format!("'{}' -> ", n))
+        .collect::<String>()
+        .add(&format!("'{}'", template_name))
 }
 
 /// Handles a dependency cycle by panicking


### PR DESCRIPTION
Removes `rustfmt.toml` and applies default Rust formatting to all source code. (Includes #12)