### PR TITLE
export some types directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_proto"
-version = "0.3.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Create config files for entities in Bevy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_proto"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Create config files for entities in Bevy"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Then add it to your app like so:
 
 ```rust
 use bevy::prelude::*;
-use bevy_proto::plugin::ProtoPlugin;
+use bevy_proto::ProtoPlugin;
 
 fn main() {
     App::new()

--- a/src/data.rs
+++ b/src/data.rs
@@ -440,7 +440,7 @@ pub trait ProtoDeserializer: DynClone {
     ///
     /// ```
     /// // The default implementation:
-    /// use bevy_proto::prototype::{Prototype, Prototypical};
+    /// use bevy_proto::{Prototype, Prototypical};
     /// fn example_deserialize(data: &str) -> Option<Box<dyn Prototypical>> {
     ///     if let Ok(value) = serde_yaml::from_str::<Prototype>(data) {
     ///         Some(Box::new(value))

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,7 +13,7 @@ use dyn_clone::DynClone;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::DefaultProtoDeserializer;
+use crate::plugin::DefaultProtoDeserializer;
 use crate::{components::ProtoComponent, prototype::Prototypical, utils::handle_cycle};
 
 /// A String newtype for a handle's asset path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,19 +74,23 @@
 //!
 extern crate bevy_proto_derive;
 
-pub mod components;
+mod components;
+pub use components::ProtoComponent;
+mod plugin;
+pub use plugin::ProtoPlugin;
+mod prototype;
+pub use prototype::{deserialize_templates_list, Prototype, Prototypical};
+
 pub mod data;
-pub mod plugin;
-pub mod prototype;
 #[macro_use]
 mod utils;
 
 pub mod prelude {
     //! Includes all public types and the macro to derive [`ProtoComponent`](super::components::ProtoComponent).
 
-    pub use super::components::*;
+    pub use super::components::ProtoComponent;
     pub use super::data::*;
-    pub use super::plugin::*;
+    pub use super::plugin::ProtoPlugin;
     pub use super::prototype::{Prototype, Prototypical};
     pub use bevy_proto_derive::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 extern crate bevy_proto_derive;
 
 mod components;
+pub use bevy_proto_derive::ProtoComponent;
 pub use components::ProtoComponent;
 mod plugin;
 pub use plugin::ProtoPlugin;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -24,7 +24,7 @@ impl ProtoPlugin {
     /// # Examples
     ///
     /// ```
-    /// use bevy_proto::plugin::ProtoPlugin;
+    /// use bevy_proto::ProtoPlugin;
     ///
     /// let plugin = ProtoPlugin::with_dir("assets/config");
     /// ```
@@ -49,7 +49,7 @@ impl ProtoPlugin {
     /// # Examples
     ///
     /// ```
-    /// use bevy_proto::plugin::ProtoPlugin;
+    /// use bevy_proto::ProtoPlugin;
     ///
     /// let plugin = ProtoPlugin::with_dir_recursive("assets/config");
     /// ```
@@ -73,7 +73,7 @@ impl ProtoPlugin {
     /// # Examples
     ///
     /// ```
-    /// use bevy_proto::plugin::ProtoPlugin;
+    /// use bevy_proto::ProtoPlugin;
     ///
     /// let plugin = ProtoPlugin::with_dirs(vec![
     ///   String::from("assets/config"),
@@ -100,7 +100,7 @@ impl ProtoPlugin {
     /// # Examples
     ///
     /// ```
-    /// use bevy_proto::plugin::ProtoPlugin;
+    /// use bevy_proto::ProtoPlugin;
     ///
     /// let plugin = ProtoPlugin::with_dirs(vec![
     ///   String::from("assets/config"),


### PR DESCRIPTION
Per #14 this PR hides some modules and exports their types directly.

- Hides modules `components`, `plugin`, and `prototype`.
- Exports types `ProtoComponent`, `ProtoPlugin`, `Prototype`, and `Prototypical` directly, and in the prelude.
- Exports the `deserialize_templates_list` function directly, but _not_ the in the prelude.
- Bumps the version number for the possible breaking change.