### PR TITLE
add typetag peer dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ components:
 ```toml
 [dependencies]
 bevy_proto = "0.4"
+typetag = "0.1"
 ```
 
 Then add it to your app like so:


### PR DESCRIPTION
When adding this dependency to a project, the project would fail to compile until typetag was added as a top level dependency.

This is probably not ideal, but for now we can at least document the behaviour.