### PR TITLE
Implement hot reloading for prototypes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ typetag = "0.2"
 serde_yaml = "0.9"
 dyn-clone = "1.0"
 indexmap = "1.9"
+crossbeam-channel = { version = "0.5", optional = true }
+notify = { version = "=5.0.0-pre.15", optional = true }
 
 [dev-dependencies]
 bevy = "0.8"
@@ -28,6 +30,8 @@ default = ["analysis"]
 analysis = []
 # If enabled, panics when a dependency cycle is found, otherwise logs a warning
 no_cycles = ["analysis"]
+# If enabled, allows for hot reloading
+hot_reloading = ["dep:crossbeam-channel", "dep:notify"]
 
 [[example]]
 name = "basic"

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,12 +9,8 @@ use bevy::ecs::system::EntityCommands;
 use bevy::prelude::{FromWorld, Handle};
 use bevy::reflect::Uuid;
 use bevy::utils::HashMap;
-#[cfg(feature = "hot_reloading")]
-use crossbeam_channel::Receiver;
 use dyn_clone::DynClone;
 use indexmap::IndexSet;
-#[cfg(feature = "hot_reloading")]
-use notify::{Event, RecommendedWatcher, RecursiveMode, Result, Watcher};
 use serde::{Deserialize, Serialize};
 
 use crate::plugin::DefaultProtoDeserializer;
@@ -40,34 +36,6 @@ impl From<&HandlePath> for HandleId {
 
 type UuidHandleMap = HashMap<Uuid, HandleUntyped>;
 
-// Copied from bevy_asset's implementation
-// https://github.com/bevyengine/bevy/blob/main/crates/bevy_asset/src/filesystem_watcher.rs
-#[cfg(feature = "hot_reloading")]
-pub(crate) struct FilesystemWatcher {
-    pub(crate) watcher: RecommendedWatcher,
-    pub(crate) receiver: Receiver<Result<Event>>,
-}
-
-#[cfg(feature = "hot_reloading")]
-impl FilesystemWatcher {
-    /// Watch for changes recursively at the provided path.
-    pub fn watch<P: AsRef<std::path::Path>>(&mut self, path: P) -> Result<()> {
-        self.watcher.watch(path.as_ref(), RecursiveMode::Recursive)
-    }
-}
-
-#[cfg(feature = "hot_reloading")]
-impl Default for FilesystemWatcher {
-    fn default() -> Self {
-        let (sender, receiver) = crossbeam_channel::unbounded();
-        let watcher: RecommendedWatcher = RecommendedWatcher::new(move |res| {
-            sender.send(res).expect("Watch event send failure.");
-        })
-        .expect("Failed to create filesystem watcher.");
-        FilesystemWatcher { watcher, receiver }
-    }
-}
-
 /// A resource containing data for all prototypes that need data stored
 pub struct ProtoData {
     /// Maps Prototype Name -> Component Type -> HandleId -> Asset Type -> HandleUntyped
@@ -79,9 +47,6 @@ pub struct ProtoData {
         >,
     >,
     pub(crate) prototypes: HashMap<String, Box<dyn Prototypical>>,
-
-    #[cfg(feature = "hot_reloading")]
-    pub(crate) watcher: FilesystemWatcher,
 }
 
 impl ProtoData {
@@ -90,8 +55,6 @@ impl ProtoData {
         Self {
             handles: HashMap::default(),
             prototypes: HashMap::default(),
-            #[cfg(feature = "hot_reloading")]
-            watcher: FilesystemWatcher::default(),
         }
     }
 
@@ -261,8 +224,6 @@ impl FromWorld for ProtoData {
         let mut myself = Self {
             handles: Default::default(),
             prototypes: HashMap::default(),
-            #[cfg(feature = "hot_reloading")]
-            watcher: FilesystemWatcher::default(),
         };
 
         let options = world
@@ -536,9 +497,6 @@ pub struct ProtoDataOptions {
     /// };
     /// ```
     pub extensions: Option<Vec<&'static str>>,
-    /// Whether to enable hot-reloading or not
-    #[cfg(feature = "hot_reloading")]
-    pub hot_reload: bool,
 }
 
 impl Default for ProtoDataOptions {
@@ -548,8 +506,6 @@ impl Default for ProtoDataOptions {
             recursive_loading: Default::default(),
             deserializer: Box::new(DefaultProtoDeserializer),
             extensions: Default::default(),
-            #[cfg(feature = "hot_reloading")]
-            hot_reload: false,
         }
     }
 }

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -1,0 +1,81 @@
+use bevy::prelude::{App, Plugin, Res, ResMut};
+use crossbeam_channel::Receiver;
+use notify::{Event, RecommendedWatcher, RecursiveMode, Result, Watcher};
+
+use crate::prelude::{ProtoData, ProtoDataOptions};
+
+// Copied from bevy_asset's implementation
+// https://github.com/bevyengine/bevy/blob/main/crates/bevy_asset/src/filesystem_watcher.rs
+struct FilesystemWatcher {
+    watcher: RecommendedWatcher,
+    receiver: Receiver<Result<Event>>,
+}
+
+impl FilesystemWatcher {
+    /// Watch for changes recursively at the provided path.
+    fn watch<P: AsRef<std::path::Path>>(&mut self, path: P) -> Result<()> {
+        self.watcher.watch(path.as_ref(), RecursiveMode::Recursive)
+    }
+}
+
+impl Default for FilesystemWatcher {
+    fn default() -> Self {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let watcher: RecommendedWatcher = RecommendedWatcher::new(move |res| {
+            sender.send(res).expect("Watch event send failure.");
+        })
+        .expect("Failed to create filesystem watcher.");
+        FilesystemWatcher { watcher, receiver }
+    }
+}
+
+// Copied from bevy_asset's filesystem watching implementation:
+// https://github.com/bevyengine/bevy/blob/main/crates/bevy_asset/src/io/file_asset_io.rs#L167-L199
+fn watch_for_changes(
+    watcher: Res<FilesystemWatcher>,
+    mut proto_data: ResMut<ProtoData>,
+    options: Res<ProtoDataOptions>,
+) {
+    let mut changed = bevy::utils::HashSet::default();
+    loop {
+        let event = match watcher.receiver.try_recv() {
+            Ok(result) => result.unwrap(),
+            Err(crossbeam_channel::TryRecvError::Empty) => break,
+            Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                panic!("FilesystemWatcher disconnected.")
+            }
+        };
+        if let notify::event::Event {
+            kind: notify::event::EventKind::Modify(_),
+            paths,
+            ..
+        } = event
+        {
+            for path in &paths {
+                if !changed.contains(path) {
+                    if let Ok(data) = std::fs::read_to_string(path) {
+                        if let Some(proto) = options.deserializer.deserialize(&data) {
+                            proto_data
+                                .prototypes
+                                .insert(proto.name().to_string(), proto);
+                        }
+                    }
+                }
+            }
+            changed.extend(paths);
+        }
+    }
+}
+
+pub(crate) struct HotReloadPlugin {
+    pub(crate) path: String,
+}
+
+impl Plugin for HotReloadPlugin {
+    fn build(&self, app: &mut App) {
+        let mut watcher = FilesystemWatcher::default();
+        watcher.watch(self.path.clone()).unwrap();
+
+        app.insert_resource(watcher).add_system(watch_for_changes);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@ pub use plugin::ProtoPlugin;
 mod prototype;
 pub use prototype::{deserialize_templates_list, Prototype, Prototypical};
 
+#[cfg(feature = "hot_reloading")]
+mod hot_reload;
+
 pub mod data;
 #[macro_use]
 mod utils;


### PR DESCRIPTION
This PR implements hot-reloading if the feature `hot_reloading` is enabled. Note that hot reloading only works for the first path specified in `ProtoDataOptions`.
The core implementation was copied from `bevy_asset`, with minor details changed to fit.  

This PR will be obsoleted by #18, as Bevy's native asset hot reloading can be used instead.