### PR TITLE
Remove `Res` from `Prototypical` and `ProtoComponent` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ struct Inventory(Option<Vec<String>>);
 #[typetag::serde] // Required
 impl ProtoComponent for Inventory {
     // Required
-    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &AssetServer) {
         commands.insert(
             Self (self.0.clone())
         );
@@ -294,7 +294,7 @@ struct Creature {
 #[typetag::serde]
 impl ProtoComponent for Creature {
     // Required
-    fn insert_self(&self, proto_commands: &mut ProtoCommands, asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, proto_commands: &mut ProtoCommands, asset_server: &AssetServer) {
         let handle: Handle<Image> = asset_server.load(self.texture_path.as_str());
         let entity_commands = proto_commands.raw_commands();
 
@@ -326,7 +326,7 @@ struct Creature {
 #[typetag::serde]
 impl ProtoComponent for Creature {
     // Required
-    fn insert_self(&self, proto_commands: &mut ProtoCommands, asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, proto_commands: &mut ProtoCommands, asset_server: &AssetServer) {
         let texture: Handle<Image> = proto_commands
             .get_handle(self, &self.texture_path)
             .expect("Expected Image handle to have been created");
@@ -393,7 +393,7 @@ impl Prototypical for CustomPrototype {
   fn create_commands<'w, 's, 'a, 'p>(
     &'p self, 
     entity_commands: EntityCommands<'w, 's, 'a>, 
-    proto_data: &'p Res<'_, ProtoData>
+    proto_data: &'p ProtoData
   ) -> ProtoCommands<'w, 's, 'a, 'p> { 
     todo!() 
   }
@@ -470,8 +470,8 @@ breakdown of the top current/potential issues:
     prototype: T, 
     my_asset: Handle<Image>,
     commands: &mut Commands,
-    data: &Res<ProtoData>,
-    asset_server: &Res<AssetServer>,
+    data: &ProtoData,
+    asset_server: &AssetServer,
   ) {
     // Attach fictional OtherComponent with asset "my_asset" which should unload when despawned
     prototype.spawn(commands, data, asset_server).insert(OtherComponent(my_asset));

--- a/bevy_proto_derive/src/lib.rs
+++ b/bevy_proto_derive/src/lib.rs
@@ -78,7 +78,7 @@ pub fn proto_comp_derive(input: TokenStream) -> TokenStream {
             fn insert_self(
                 &self,
                 commands: &mut bevy_proto::prelude::ProtoCommands,
-                asset_server: &bevy::prelude::Res<bevy::prelude::AssetServer>,
+                asset_server: &bevy::prelude::AssetServer,
             ) {
                 #generator;
             }

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -46,7 +46,7 @@ trait AsEmoji {
 fn create_emoji<T: AsEmoji + ProtoComponent>(
     component: &T,
     commands: &mut ProtoCommands,
-    _asset_server: &Res<AssetServer>,
+    _asset_server: &AssetServer,
 ) {
     commands.insert(component.as_emoji());
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,7 +17,7 @@ struct Person {
 /// Note that we must apply the `#[typetag::serde]` attribute
 #[typetag::serde]
 impl ProtoComponent for Person {
-    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &AssetServer) {
         /// Here, we create the component we're going to insert.
         /// This can really be any valid Bevy component type, but we'll
         /// use `Person` since it's so simple

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -83,7 +83,7 @@ struct SpriteBundleDef {
 
 #[typetag::serde]
 impl ProtoComponent for SpriteBundleDef {
-    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &AssetServer) {
         // === Get Prepared Assets === //
         let texture: Handle<Image> = asset_server.get_handle(&self.texture_path);
 

--- a/examples/bundles.rs
+++ b/examples/bundles.rs
@@ -12,7 +12,7 @@ struct SpriteBundleDef {
 
 #[typetag::serde]
 impl ProtoComponent for SpriteBundleDef {
-    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &Res<AssetServer>) {
+    fn insert_self(&self, commands: &mut ProtoCommands, _asset_server: &AssetServer) {
         // === Get Prepared Assets === //
         let texture: Handle<Image> = commands
             .get_handle(self, &self.texture_path)

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,5 +1,5 @@
 //! Contains the [`ProtoComponent`] trait.
-use bevy::prelude::{AssetServer, Res, World};
+use bevy::prelude::{AssetServer, World};
 
 use crate::data::{ProtoCommands, ProtoData};
 use crate::prototype::Prototypical;
@@ -63,7 +63,7 @@ use crate::prototype::Prototypical;
 /// impl ProtoComponent for Inventory {
 ///     // The `Inventory` implementation of `insert_self` inserts two components:
 ///     // one for `Items`, and one for `QuestItems`.
-///     fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>) {
+///     fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &AssetServer) {
 ///         commands.insert(self.items.clone());
 ///         commands.insert(self.quest_items.clone());
 ///     }
@@ -76,7 +76,7 @@ use crate::prototype::Prototypical;
 #[typetag::serde(tag = "type", content = "value")]
 pub trait ProtoComponent: Send + Sync + 'static {
     /// Defines how this struct inserts components and/or bundles into an entity.
-    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &Res<AssetServer>);
+    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &AssetServer);
     /// Defines how this struct creates and inserts asset handles for later use.
     #[allow(unused_variables)]
     fn prepare(&self, world: &mut World, prototype: &dyn Prototypical, data: &mut ProtoData) {}

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -5,7 +5,7 @@ use std::slice::Iter;
 
 use bevy::ecs::prelude::Commands;
 use bevy::ecs::system::EntityCommands;
-use bevy::prelude::{AssetServer, Res};
+use bevy::prelude::AssetServer;
 use indexmap::IndexSet;
 use serde::{
     de::{self, Error, SeqAccess, Visitor},
@@ -46,7 +46,7 @@ pub trait Prototypical: 'static + Send + Sync {
     fn create_commands<'w, 's, 'a, 'p>(
         &'p self,
         entity: EntityCommands<'w, 's, 'a>,
-        data: &'p Res<ProtoData>,
+        data: &'p ProtoData,
     ) -> ProtoCommands<'w, 's, 'a, 'p>;
 
     /// Spawns an entity with this prototype's component structure.
@@ -63,7 +63,7 @@ pub trait Prototypical: 'static + Send + Sync {
     /// use bevy::prelude::*;
     /// use bevy_proto::prelude::{ProtoData, Prototype, Prototypical};
     ///
-    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>) {
+    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>) {
     ///     let proto: Prototype = serde_yaml::from_str(r#"
     ///     name: My Prototype
     ///     components:
@@ -82,8 +82,8 @@ pub trait Prototypical: 'static + Send + Sync {
     fn spawn<'w, 's, 'a, 'p>(
         &'p self,
         commands: &'a mut Commands<'w, 's>,
-        data: &Res<ProtoData>,
-        asset_server: &Res<AssetServer>,
+        data: &ProtoData,
+        asset_server: &AssetServer,
     ) -> EntityCommands<'w, 's, 'a> {
         let entity = commands.spawn_empty();
         self.insert(entity, data, asset_server)
@@ -108,7 +108,7 @@ pub trait Prototypical: 'static + Send + Sync {
     /// #[derive(Component)]
     /// struct Player(pub Entity);
     ///
-    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: &Res<AssetServer>, player: Query<&Player>) {
+    /// fn setup_system(mut commands: Commands, data: Res<ProtoData>, asset_server: Res<AssetServer>, player: Query<&Player>) {
     ///     let proto: Prototype = serde_yaml::from_str(r#"
     ///     name: My Prototype
     ///     components:
@@ -131,8 +131,8 @@ pub trait Prototypical: 'static + Send + Sync {
     fn insert<'w, 's, 'a, 'p>(
         &'p self,
         entity: EntityCommands<'w, 's, 'a>,
-        data: &Res<ProtoData>,
-        asset_server: &Res<AssetServer>,
+        data: &ProtoData,
+        asset_server: &AssetServer,
     ) -> EntityCommands<'w, 's, 'a> {
         let mut proto_commands = self.create_commands(entity, data);
 
@@ -157,8 +157,8 @@ fn spawn_internal<'a>(
     templates: Rev<Iter<'a, String>>,
     components: Iter<'a, Box<dyn ProtoComponent>>,
     proto_commands: &mut ProtoCommands,
-    data: &'a Res<ProtoData>,
-    asset_server: &Res<AssetServer>,
+    data: &'a ProtoData,
+    asset_server: &AssetServer,
     traversed: &mut IndexSet<&'a str>,
 ) {
     // We insert first on the off chance that someone made a prototype its own template...
@@ -229,7 +229,7 @@ impl Prototypical for Prototype {
     fn create_commands<'w, 's, 'a, 'p>(
         &'p self,
         entity: EntityCommands<'w, 's, 'a>,
-        data: &'p Res<ProtoData>,
+        data: &'p ProtoData,
     ) -> ProtoCommands<'w, 's, 'a, 'p> {
         data.get_commands(self, entity)
     }


### PR DESCRIPTION
The motivation for this is to (hackily) allow a prototype to spawn in another prototype:

```rust
impl ProtoComponent for MyPrototype {
    fn insert_self(&self, commands: &mut ProtoCommands, asset_server: &AssetServer) {
        let child;
        unsafe {
            let cmd = commands.raw_commands().commands() as *mut Commands;
            let proto = commands
                .raw_data()
                .get_prototype(&self.child_prototype)
                .unwrap();
            child = proto
                .spawn(&mut *cmd, commands.raw_data(), asset_server)
                .id();
        }
    }
    commands
        .spawn()
        .add_child(child);
    }
}
```