### PR TITLE
Fix: Derive macro requiring backend crate as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_proto"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Create config files for entities in Bevy"
@@ -57,7 +57,7 @@ bevy_sprite = ["bevy/bevy_sprite", "bevy_proto_backend/bevy_sprite"]
 bevy_text = ["bevy/bevy_text", "bevy_proto_backend/bevy_text"]
 
 [dependencies]
-bevy_proto_backend = { version = "0.1", path = "./bevy_proto_backend" }
+bevy_proto_backend = { version = "0.1.1", path = "./bevy_proto_backend" }
 bevy = { version = ">=0.10.1", default-features = false, features = ["bevy_asset"] }
 anyhow = "1.0"
 serde = "1.0"

--- a/bevy_proto_backend/Cargo.toml
+++ b/bevy_proto_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_proto_backend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Backend crate for bevy_proto"
@@ -44,7 +44,7 @@ bevy_sprite = ["bevy/bevy_sprite"]
 bevy_text = ["bevy/bevy_text"]
 
 [dependencies]
-bevy_proto_derive = { version = "0.3", path = "../bevy_proto_derive" }
+bevy_proto_derive = { version = "0.3.1", path = "../bevy_proto_derive" }
 bevy = { version = ">=0.10.1", default-features = false, features = ["bevy_asset"] }
 anyhow = "1.0"
 serde = "1.0"

--- a/bevy_proto_derive/Cargo.toml
+++ b/bevy_proto_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_proto_derive"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Derive macro for use with bevy_proto"

--- a/bevy_proto_derive/src/utils.rs
+++ b/bevy_proto_derive/src/utils.rs
@@ -1,12 +1,20 @@
 use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_crate::{crate_name, FoundCrate};
+use proc_macro_crate::{crate_name, Error, FoundCrate};
 use quote::quote;
 
-/// Returns a path to the `bevy_proto_backend` crate.
+/// Returns a path to either the `bevy_proto_backend` crate or `bevy_proto::backend` module.
 pub(crate) fn get_proto_crate() -> TokenStream {
-    get_crate_path(
-        crate_name("bevy_proto_backend").expect("bevy_proto_backend is present in `Cargo.toml`"),
-    )
+    match crate_name("bevy_proto_backend") {
+        Ok(found_crate) => get_crate_path(found_crate),
+        Err(Error::CrateNotFound { .. }) => {
+            let path = get_crate_path(
+                crate_name("bevy_proto")
+                    .expect("bevy_proto or bevy_proto_backend should be present in `Cargo.toml`"),
+            );
+            quote!(#path::backend)
+        }
+        Err(error) => panic!("{}", error),
+    }
 }
 
 /// Returns a path to the `bevy` crate.
@@ -19,7 +27,7 @@ fn get_crate_path(found_crate: FoundCrate) -> TokenStream {
         FoundCrate::Itself => quote!(crate),
         FoundCrate::Name(name) => {
             let ident = Ident::new(&name, Span::call_site());
-            quote!( #ident )
+            quote!( ::#ident )
         }
     }
 }


### PR DESCRIPTION
## Problem
Fixes a bug found by `@Tsudico` on [Discord](https://discord.com/channels/691052431525675048/1097177306402926773/1099742611033571488):

> I'm trying to figure out the basic schematic example. It runs as an example in a cloned bevy_proto, but when I copy the code into a new project it fails with the following error for any derived Schematic:
> ```
> message: bevy_proto_backend is present in Cargo.toml: CrateNotFound { crate_name: "bevy_proto_backend", path: "f:\Repositories\rust\projects\bevy_proto_test\Cargo.toml" }
> ```
> 
> Cargo.toml has this under dependencies:
> ```toml
> [dependencies]
> bevy = "0.10.1"
> bevy_proto = "0.8"
> ```
> 
> Am I missing something in the Cargo.toml?

## Solution

Since `bevy_proto` and `bevy_proto_backend` need to use the derive macro, we can't just use a feature to swap between sources. Instead, we search for one and then the other if not found.

Since this is a very problematic bug that makes `bevy_proto` unusable (at least, the macros), I'm going to publish this version right away and yank the previous version.