### PR TITLE
Optional spawning and `SchematicContext`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,18 @@ This crate is mostly feature-complete.
 There are a few more things I think would be really nice to add. Below is a list of my current goals and what's been
 accomplished thus far:
 
-| Goal                                             | Status             |
-|--------------------------------------------------|--------------------|
-| Reflection support                               | :white_check_mark: |
-| Nested prototypes                                | :white_check_mark: |
-| Package-specifier                                | :construction:     |
-| Configurable schematics filtering and processing | :construction:     |
-| Prototype arguments                              | :construction:     |
-| Entity-less prototypes                           | :construction:     |
-| Value access                                     | :construction:     |
-| Custom file format support                       | :construction:     |
-| Improved documentation                           | :construction:     |
-| Benchmarks                                       | :construction:     |
+| Goal                                             | Status |
+|--------------------------------------------------|--------|
+| Reflection support                               | ✅      |
+| Nested prototypes                                | ✅      |
+| Package-specifier                                | 🚧     |
+| Configurable schematics filtering and processing | 🚧     |
+| Prototype arguments                              | 🚧     |
+| Entity-less prototypes                           | ✅      |
+| Value access                                     | 🚧     |
+| Custom file format support                       | 🚧     |
+| Improved documentation                           | 🚧     |
+| Benchmarks                                       | 🚧     |
 
 ## 🕰 Previous Versions
 

--- a/assets/examples/basic_schematic/Player.prototype.ron
+++ b/assets/examples/basic_schematic/Player.prototype.ron
@@ -3,7 +3,6 @@
   schematics: {
     "basic_schematic::Playable": (),
     "basic_schematic::Alignment": Good,
-    "basic_schematic::PlayerHealth": (100),
     // This schematic is provided by `bevy_proto` and resolves
     // to a Bevy `SpriteBundle`:
     "bevy_proto::custom::SpriteBundle": (

--- a/assets/examples/basic_schematic/PlayerConfig.prototype.ron
+++ b/assets/examples/basic_schematic/PlayerConfig.prototype.ron
@@ -1,0 +1,9 @@
+(
+  name: "PlayerConfig",
+  // Since this prototype only contains a resource,
+  // we can mark it as not needing an entity to be spawned.
+  entity: false,
+  schematics: {
+    "basic_schematic::MaxPlayers": (1),
+  }
+)

--- a/bevy_proto_backend/src/impls/bevy_impls/asset.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/asset.rs
@@ -1,13 +1,11 @@
 use bevy::app::App;
 use bevy::asset::{Asset, AssetServer, Handle};
-use bevy::ecs::world::EntityMut;
 
 use crate::impls::macros::register_schematic;
 use bevy_proto_derive::impl_external_schematic;
 
 use crate::proto::ProtoAsset;
-use crate::schematics::FromSchematicInput;
-use crate::tree::EntityTree;
+use crate::schematics::{FromSchematicInput, SchematicContext};
 
 #[allow(unused_variables)]
 pub(super) fn register(app: &mut App) {
@@ -70,10 +68,10 @@ impl_external_schematic! {
     struct Handle<T: Asset> {}
     // ---
     impl<T: Asset> FromSchematicInput<ProtoAsset> for Handle<T> {
-        fn from_input(input: ProtoAsset, entity: &mut EntityMut, _: &EntityTree) -> Self {
+        fn from_input(input: ProtoAsset, context: &mut SchematicContext) -> Self {
             match input {
-                ProtoAsset::AssetPath(path) => entity.world().resource::<AssetServer>().load(path),
-                ProtoAsset::HandleId(handle_id) => entity.world().resource::<AssetServer>().get_handle(handle_id),
+                ProtoAsset::AssetPath(path) => context.world().resource::<AssetServer>().load(path),
+                ProtoAsset::HandleId(handle_id) => context.world().resource::<AssetServer>().get_handle(handle_id),
             }
         }
     }

--- a/bevy_proto_backend/src/impls/bevy_impls/text.rs
+++ b/bevy_proto_backend/src/impls/bevy_impls/text.rs
@@ -1,12 +1,11 @@
 use bevy::app::App;
-use bevy::ecs::world::EntityMut;
 use bevy::math::Vec2;
 use bevy::reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 use bevy::text::{BreakLineOn, Text, Text2dBounds, TextAlignment, TextSection, TextStyle};
 
 use crate::impls::macros::{from_to, from_to_default, from_to_input, register_schematic};
 use crate::proto::{ProtoAsset, ProtoColor};
-use crate::schematics::FromSchematicInput;
+use crate::schematics::{FromSchematicInput, SchematicContext};
 use bevy_proto_derive::impl_external_schematic;
 
 pub(super) fn register(app: &mut App) {
@@ -34,10 +33,10 @@ impl_external_schematic! {
     from_to_input! {
         Text,
         TextInput,
-        move |input: Input, entity: &mut EntityMut, tree| {
+        move |input: Input, context: &mut SchematicContext| {
             let mut sections = Vec::with_capacity(input.sections.len());
             for section in input.sections {
-                sections.push(FromSchematicInput::from_input(section, &mut *entity, tree));
+                sections.push(FromSchematicInput::from_input(section, &mut *context));
             }
 
             Self {
@@ -66,9 +65,9 @@ impl_external_schematic! {
     from_to_input! {
         TextSection,
         TextSectionInput,
-        |input: Input, entity, tree| Self {
+        |input: Input, context| Self {
             value: input.value,
-            style: FromSchematicInput::from_input(input.style, entity, tree)
+            style: FromSchematicInput::from_input(input.style, context)
         }
     }
 
@@ -81,8 +80,8 @@ impl_external_schematic! {
     from_to_input! {
         TextStyle,
         TextStyleInput,
-        |input: Input, entity, tree| Self {
-            font: FromSchematicInput::from_input(input.font, entity, tree),
+        |input: Input, context| Self {
+            font: FromSchematicInput::from_input(input.font, context),
             font_size: input.font_size,
             color: input.color.into(),
         }

--- a/bevy_proto_backend/src/impls/macros.rs
+++ b/bevy_proto_backend/src/impls/macros.rs
@@ -78,10 +78,9 @@ macro_rules! from_to_input {
             impl $crate::schematics::FromSchematicInput<Input> for $mock {
                 fn from_input(
                     input: Input,
-                    entity: &mut bevy::ecs::world::EntityMut,
-                    tree: &$crate::tree::EntityTree,
+                    context: &mut $crate::schematics::SchematicContext,
                 ) -> Self {
-                    $body(input, entity, tree)
+                    $body(input, context)
                 }
             }
         };
@@ -92,10 +91,9 @@ macro_rules! from_to_input {
             impl $crate::schematics::FromSchematicInput<Input> for $real {
                 fn from_input(
                     input: Input,
-                    entity: &mut bevy::ecs::world::EntityMut,
-                    tree: &$crate::tree::EntityTree,
+                    context: &mut $crate::schematics::SchematicContext,
                 ) -> Self {
-                    $body(input, entity, tree)
+                    $body(input, context)
                 }
             }
         };

--- a/bevy_proto_backend/src/proto/commands.rs
+++ b/bevy_proto_backend/src/proto/commands.rs
@@ -2,13 +2,12 @@ use std::marker::PhantomData;
 
 use bevy::asset::Assets;
 use bevy::ecs::system::{Command, EntityCommands, SystemParam};
-use bevy::ecs::world::EntityMut;
 use bevy::prelude::{Commands, Entity, Mut, World};
 
 use crate::proto::{Config, Prototypical};
 use crate::registration::ProtoRegistry;
-use crate::schematics::DynamicSchematic;
-use crate::tree::{EntityTree, EntityTreeNode};
+use crate::schematics::{DynamicSchematic, SchematicContext};
+use crate::tree::EntityTreeNode;
 
 /// A system parameter similar to [`Commands`], but catered towards [prototypes].
 ///
@@ -164,8 +163,8 @@ impl<T: Prototypical> Command for ProtoInsertCommand<T> {
         self.data.assert_is_registered(world);
 
         self.data
-            .for_each_schematic(world, true, |schematic, entity, tree| {
-                schematic.apply(entity, tree).unwrap();
+            .for_each_schematic(world, true, |schematic, context| {
+                schematic.apply(context).unwrap();
             });
     }
 }
@@ -191,8 +190,8 @@ impl<T: Prototypical> Command for ProtoRemoveCommand<T> {
         self.data.assert_is_registered(world);
 
         self.data
-            .for_each_schematic(world, false, |schematic, entity, tree| {
-                schematic.remove(entity, tree).unwrap();
+            .for_each_schematic(world, false, |schematic, context| {
+                schematic.remove(context).unwrap();
             });
     }
 }
@@ -225,7 +224,7 @@ impl<T: Prototypical> ProtoCommandData<T> {
 
     fn for_each_entity<F>(&self, world: &mut World, is_apply: bool, callback: F)
     where
-        F: Fn(&EntityTreeNode, &mut EntityMut, &EntityTree, &Assets<T>, &mut T::Config),
+        F: Fn(&EntityTreeNode, &mut SchematicContext, &Assets<T>, &mut T::Config),
     {
         world.resource_scope(|world: &mut World, registry: Mut<ProtoRegistry<T>>| {
             world.resource_scope(|world: &mut World, mut config: Mut<T::Config>| {
@@ -238,17 +237,19 @@ impl<T: Prototypical> ProtoCommandData<T> {
                     for node in entity_tree.iter() {
                         entity_tree.set_current(node);
 
-                        let mut entity = world.entity_mut(node.entity());
+                        let mut context = SchematicContext::new(world, &entity_tree);
 
                         #[cfg(feature = "auto_name")]
-                        if is_apply && !entity.contains::<bevy::core::Name>() {
-                            entity.insert(bevy::core::Name::new(format!(
-                                "{} (Prototype)",
-                                node.id()
-                            )));
+                        if let Some(mut entity) = context.entity_mut() {
+                            if is_apply && !entity.contains::<bevy::core::Name>() {
+                                entity.insert(bevy::core::Name::new(format!(
+                                    "{} (Prototype)",
+                                    node.id()
+                                )));
+                            }
                         }
 
-                        callback(node, &mut entity, &entity_tree, &prototypes, &mut config);
+                        callback(node, &mut context, &prototypes, &mut config);
                     }
                 })
             })
@@ -261,48 +262,44 @@ impl<T: Prototypical> ProtoCommandData<T> {
     /// [prototype]: Prototypical
     fn for_each_schematic<F>(&self, world: &mut World, is_apply: bool, callback: F)
     where
-        F: Fn(&DynamicSchematic, &mut EntityMut, &EntityTree),
+        F: Fn(&DynamicSchematic, &mut SchematicContext),
     {
-        self.for_each_entity(
-            world,
-            is_apply,
-            |node, entity, entity_tree, prototypes, config| {
-                let on_before_prototype = if is_apply {
-                    Config::<T>::on_before_apply_prototype
-                } else {
-                    Config::<T>::on_before_remove_prototype
-                };
-                let on_after_prototype = if is_apply {
-                    Config::<T>::on_after_apply_prototype
-                } else {
-                    Config::<T>::on_after_remove_prototype
-                };
-                let on_before_schematic = if is_apply {
-                    Config::<T>::on_before_apply_schematic
-                } else {
-                    Config::<T>::on_before_remove_schematic
-                };
-                let on_after_schematic = if is_apply {
-                    Config::<T>::on_after_apply_schematic
-                } else {
-                    Config::<T>::on_after_remove_schematic
-                };
+        self.for_each_entity(world, is_apply, |node, context, prototypes, config| {
+            let on_before_prototype = if is_apply {
+                Config::<T>::on_before_apply_prototype
+            } else {
+                Config::<T>::on_before_remove_prototype
+            };
+            let on_after_prototype = if is_apply {
+                Config::<T>::on_after_apply_prototype
+            } else {
+                Config::<T>::on_after_remove_prototype
+            };
+            let on_before_schematic = if is_apply {
+                Config::<T>::on_before_apply_schematic
+            } else {
+                Config::<T>::on_before_remove_schematic
+            };
+            let on_after_schematic = if is_apply {
+                Config::<T>::on_after_apply_schematic
+            } else {
+                Config::<T>::on_after_remove_schematic
+            };
 
-                for handle_id in node.prototypes() {
-                    let handle = prototypes.get_handle(*handle_id);
-                    let proto = prototypes.get(&handle).unwrap();
+            for handle_id in node.prototypes() {
+                let handle = prototypes.get_handle(*handle_id);
+                let proto = prototypes.get(&handle).unwrap();
 
-                    on_before_prototype(config, proto, entity, entity_tree);
+                on_before_prototype(config, proto, context);
 
-                    for (_, schematic) in proto.schematics().iter() {
-                        on_before_schematic(config, schematic, entity, entity_tree);
-                        callback(schematic, entity, entity_tree);
-                        on_after_schematic(config, schematic, entity, entity_tree);
-                    }
-
-                    on_after_prototype(config, proto, entity, entity_tree);
+                for (_, schematic) in proto.schematics().iter() {
+                    on_before_schematic(config, schematic, context);
+                    callback(schematic, context);
+                    on_after_schematic(config, schematic, context);
                 }
-            },
-        );
+
+                on_after_prototype(config, proto, context);
+            }
+        });
     }
 }

--- a/bevy_proto_backend/src/proto/config.rs
+++ b/bevy_proto_backend/src/proto/config.rs
@@ -1,11 +1,9 @@
 use bevy::asset::Handle;
-use bevy::ecs::world::EntityMut;
 use bevy::prelude::{FromWorld, Resource};
 
 use crate::cycles::{Cycle, CycleResponse};
 use crate::proto::Prototypical;
-use crate::schematics::DynamicSchematic;
-use crate::tree::EntityTree;
+use crate::schematics::{DynamicSchematic, SchematicContext};
 
 /// Configuration for a [prototype].
 ///
@@ -79,13 +77,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     ///
     /// [prototype]: Prototypical
     /// [`ProtoCommands`]: crate::proto::ProtoCommands
-    fn on_before_apply_prototype(
-        &mut self,
-        prototype: &T,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
-    }
+    fn on_before_apply_prototype(&mut self, prototype: &T, context: &mut SchematicContext) {}
 
     /// Callback method that's triggered _after_ a [prototype] is applied to an entity.
     ///
@@ -94,13 +86,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     ///
     /// [prototype]: Prototypical
     /// [`ProtoCommands`]: crate::proto::ProtoCommands
-    fn on_after_apply_prototype(
-        &mut self,
-        prototype: &T,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
-    }
+    fn on_after_apply_prototype(&mut self, prototype: &T, context: &mut SchematicContext) {}
 
     /// Callback method that's triggered _before_ a [prototype] is removed from an entity.
     ///
@@ -109,13 +95,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     ///
     /// [prototype]: Prototypical
     /// [`ProtoCommands`]: crate::proto::ProtoCommands
-    fn on_before_remove_prototype(
-        &mut self,
-        prototype: &T,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
-    }
+    fn on_before_remove_prototype(&mut self, prototype: &T, context: &mut SchematicContext) {}
 
     /// Callback method that's triggered _after_ a [prototype] is removed from an entity.
     ///
@@ -124,13 +104,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     ///
     /// [prototype]: Prototypical
     /// [`ProtoCommands`]: crate::proto::ProtoCommands
-    fn on_after_remove_prototype(
-        &mut self,
-        prototype: &T,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
-    }
+    fn on_after_remove_prototype(&mut self, prototype: &T, context: &mut SchematicContext) {}
 
     /// Callback method that's triggered _before_ a [schematic] is applied to an entity.
     ///
@@ -142,8 +116,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     fn on_before_apply_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
     }
 
@@ -157,8 +130,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     fn on_after_apply_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
     }
 
@@ -172,8 +144,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     fn on_before_remove_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
     }
 
@@ -187,8 +158,7 @@ pub trait Config<T: Prototypical>: Resource + FromWorld {
     fn on_after_remove_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
     }
 

--- a/bevy_proto_backend/src/proto/error.rs
+++ b/bevy_proto_backend/src/proto/error.rs
@@ -31,4 +31,9 @@ pub enum ProtoError {
         path: AssetPath<'static>,
         existing: AssetPath<'static>,
     },
+    /// Indicates that an operation that requires an entity was attempted on a prototype that doesn't require one.
+    ///
+    /// This includes attempting to register children on an entity-less prototype.
+    #[error("expected prototype with ID {id:?} to require an entity")]
+    RequiresEntity { id: String },
 }

--- a/bevy_proto_backend/src/proto/prototypical.rs
+++ b/bevy_proto_backend/src/proto/prototypical.rs
@@ -53,6 +53,12 @@ pub trait Prototypical: Asset + Sized {
     fn id(&self) -> &Self::Id;
     /// The path to this prototype's asset file.
     fn path(&self) -> &ProtoPath;
+    /// Whether or not this prototype requires an entity to be spawned.
+    ///
+    /// Defaults to `true`.
+    fn requires_entity(&self) -> bool {
+        true
+    }
     /// An immutable reference to the collection of [`Schematics`] contained in this prototype.
     fn schematics(&self) -> &Schematics;
     /// A mutable reference to the collection of [`Schematics`] contained in this prototype.

--- a/bevy_proto_backend/src/schematics/context.rs
+++ b/bevy_proto_backend/src/schematics/context.rs
@@ -1,0 +1,45 @@
+use crate::tree::{EntityAccess, EntityTree};
+use bevy::ecs::world::{EntityMut, EntityRef};
+use bevy::prelude::{Entity, World};
+
+/// The context in which a schematic instance exists.
+pub struct SchematicContext<'a, 'b> {
+    world: &'a mut World,
+    tree: &'a EntityTree<'b>,
+}
+
+impl<'a, 'b> SchematicContext<'a, 'b> {
+    pub(crate) fn new(world: &'a mut World, tree: &'a EntityTree<'b>) -> Self {
+        Self { world, tree }
+    }
+
+    /// Returns a reference to the world.
+    pub fn world(&self) -> &World {
+        self.world
+    }
+
+    /// Returns a mutable reference to the world.
+    pub fn world_mut(&mut self) -> &mut World {
+        self.world
+    }
+
+    /// Returns a reference to the entity this schematic is being applied to, if any.
+    pub fn entity(&self) -> Option<EntityRef> {
+        Some(self.world.entity(self.tree.entity()))
+    }
+
+    /// Returns a mutable reference to the entity this schematic is being applied to, if any.
+    pub fn entity_mut(&mut self) -> Option<EntityMut> {
+        Some(self.world.entity_mut(self.tree.entity()))
+    }
+
+    /// Find an entity in the tree using the given [`EntityAccess`].
+    pub fn find_entity(&self, access: &EntityAccess) -> Option<Entity> {
+        self.tree.find_entity(access)
+    }
+
+    /// Returns a reference to the entity tree.
+    pub fn tree(&self) -> &EntityTree {
+        self.tree
+    }
+}

--- a/bevy_proto_backend/src/schematics/context.rs
+++ b/bevy_proto_backend/src/schematics/context.rs
@@ -25,12 +25,14 @@ impl<'a, 'b> SchematicContext<'a, 'b> {
 
     /// Returns a reference to the entity this schematic is being applied to, if any.
     pub fn entity(&self) -> Option<EntityRef> {
-        Some(self.world.entity(self.tree.entity()))
+        self.tree.entity().map(|entity| self.world.entity(entity))
     }
 
     /// Returns a mutable reference to the entity this schematic is being applied to, if any.
     pub fn entity_mut(&mut self) -> Option<EntityMut> {
-        Some(self.world.entity_mut(self.tree.entity()))
+        self.tree
+            .entity()
+            .map(|entity| self.world.entity_mut(entity))
     }
 
     /// Find an entity in the tree using the given [`EntityAccess`].

--- a/bevy_proto_backend/src/schematics/mod.rs
+++ b/bevy_proto_backend/src/schematics/mod.rs
@@ -39,11 +39,13 @@
 
 pub use bevy_proto_derive::Schematic;
 pub use collection::*;
+pub use context::*;
 pub use dynamic::*;
 pub use error::*;
 pub use schematic::*;
 
 mod collection;
+mod context;
 mod dynamic;
 mod error;
 mod schematic;

--- a/bevy_proto_backend/src/schematics/schematic.rs
+++ b/bevy_proto_backend/src/schematics/schematic.rs
@@ -1,9 +1,8 @@
-use bevy::ecs::world::EntityMut;
 use bevy::prelude::{FromReflect, Reflect};
 use bevy::reflect::GetTypeRegistration;
 
 use crate::deps::DependenciesBuilder;
-use crate::tree::EntityTree;
+use crate::schematics::SchematicContext;
 
 /// Trait used to create a [prototype] schematic for modifying an [entity]
 /// (or the [world] in general).
@@ -15,21 +14,19 @@ use crate::tree::EntityTree;
 /// # Example
 ///
 /// ```
-/// use bevy::ecs::world::EntityMut;
 /// use bevy::prelude::{Component, FromReflect, Reflect};
-/// use bevy_proto_backend::schematics::Schematic;
-/// use bevy_proto_backend::tree::EntityTree;
+/// use bevy_proto_backend::schematics::{Schematic, SchematicContext};
 /// #[derive(Component, Reflect, FromReflect)]
 /// struct PlayerId(usize);
 ///
 /// impl Schematic for PlayerId {
 ///   type Input = Self;
 ///
-///   fn apply(input: &Self::Input, entity: &mut EntityMut, tree: &EntityTree) {
+///   fn apply(input: &Self::Input, context: &mut SchematicContext) {
 ///     entity.insert(Self(input.0));
 ///   }
 ///
-///   fn remove(input: &Self::Input, entity: &mut EntityMut, tree: &EntityTree) {
+///   fn remove(input: &Self::Input, context: &mut SchematicContext) {
 ///     entity.remove::<Self>();
 ///   }
 /// }
@@ -43,17 +40,17 @@ use crate::tree::EntityTree;
 pub trait Schematic: Reflect {
     /// The input type to this schematic.
     ///
-    /// This acts as an intermediary between serialized schematic information
+    /// This acts as an intermediate between serialized schematic information
     /// and the actual schematic instance.
     ///
-    /// For types that don't need an intermediary type, this can just be
+    /// For types that don't need an intermediate type, this can just be
     /// set to `Self`.
     type Input: FromReflect + GetTypeRegistration;
 
     /// Controls how this schematic is applied to the given entity.
-    fn apply(input: &Self::Input, entity: &mut EntityMut, tree: &EntityTree);
+    fn apply(input: &Self::Input, context: &mut SchematicContext);
     /// Controls how this schematic is removed from the given entity.
-    fn remove(input: &Self::Input, entity: &mut EntityMut, tree: &EntityTree);
+    fn remove(input: &Self::Input, context: &mut SchematicContext);
 
     /// Allows dependency assets to be loaded when this schematic is loaded.
     #[allow(unused_variables)]
@@ -72,11 +69,11 @@ pub trait Schematic: Reflect {
 /// [schematic]: Schematic
 /// [derive macro]: bevy_proto_derive::Schematic
 pub trait FromSchematicInput<T> {
-    fn from_input(input: T, entity: &mut EntityMut, tree: &EntityTree) -> Self;
+    fn from_input(input: T, context: &mut SchematicContext) -> Self;
 }
 
 impl<S, T: Into<S>> FromSchematicInput<T> for S {
-    fn from_input(input: T, _entity: &mut EntityMut, _tree: &EntityTree) -> S {
+    fn from_input(input: T, _context: &mut SchematicContext) -> S {
         input.into()
     }
 }

--- a/bevy_proto_backend/src/tree/builder.rs
+++ b/bevy_proto_backend/src/tree/builder.rs
@@ -58,13 +58,19 @@ impl<'a, T: Prototypical> ProtoTreeBuilder<'a, T> {
             return Ok(Some(tree));
         }
 
-        let mut tree = ProtoTree::new(handle, merge_key, prototype.id());
+        let mut tree = ProtoTree::new(handle, merge_key, prototype);
 
         if let Some(children) = prototype.children() {
             self.recurse_children(children, &mut tree, checker)?;
         }
         if let Some(templates) = prototype.templates() {
             self.recurse_templates(templates, &mut tree, checker)?;
+        }
+
+        if !tree.requires_entity() && !tree.children().is_empty() {
+            return Err(ProtoError::RequiresEntity {
+                id: prototype.id().to_string(),
+            });
         }
 
         self.registry.insert_tree(handle_id, tree);

--- a/bevy_proto_derive/src/schematic/fields.rs
+++ b/bevy_proto_derive/src/schematic/fields.rs
@@ -3,7 +3,7 @@ use quote::{quote, ToTokens};
 use syn::{Member, Type};
 
 use crate::schematic::field_attributes::{EntityConfig, FieldAttributes, ReplacementType};
-use crate::schematic::idents::{ENTITY_IDENT, INPUT_IDENT, TREE_IDENT};
+use crate::schematic::idents::{CONTEXT_IDENT, INPUT_IDENT};
 
 /// Field data for a `Schematic`.
 ///
@@ -81,14 +81,14 @@ impl SchematicField {
             ReplacementType::Asset(config) => {
                 if let Some(path) = config.path() {
                     quote!(
-                        #ENTITY_IDENT
+                        #CONTEXT_IDENT
                             .world()
                             .resource::<#bevy_crate::asset::AssetServer>()
                             .load(#path)
                     )
                 } else {
                     quote!(
-                        #ENTITY_IDENT
+                        #CONTEXT_IDENT
                             .world()
                             .resource::<#bevy_crate::asset::AssetServer>()
                             .load(
@@ -105,8 +105,7 @@ impl SchematicField {
                 quote! {
                      <#ty as #proto_crate::schematics::FromSchematicInput<#entity_ty>>::from_input(
                         #INPUT_IDENT.#member,
-                        #ENTITY_IDENT,
-                        #TREE_IDENT,
+                        #CONTEXT_IDENT,
                     )
                 }
             }
@@ -115,16 +114,14 @@ impl SchematicField {
                 quote! {
                     <#ty as #proto_crate::schematics::FromSchematicInput<#entity_ty>>::from_input(
                         #proto_crate::tree::EntityAccess::from(#path),
-                        #ENTITY_IDENT,
-                        #TREE_IDENT,
+                        #CONTEXT_IDENT,
                     )
                 }
             }
             ReplacementType::From(replacement_ty) => quote! {
                 <#ty as #proto_crate::schematics::FromSchematicInput<#replacement_ty>>::from_input(
                     #INPUT_IDENT.#member,
-                    #ENTITY_IDENT,
-                    #TREE_IDENT,
+                    #CONTEXT_IDENT,
                 )
             },
         }

--- a/bevy_proto_derive/src/schematic/idents.rs
+++ b/bevy_proto_derive/src/schematic/idents.rs
@@ -11,10 +11,8 @@ use quote::ToTokens;
 
 /// Ident for the `Schematic::Input` argument.
 pub(crate) const INPUT_IDENT: ConstIdent = ConstIdent("__input__");
-/// Ident for the `EntityMut` argument.
-pub(crate) const ENTITY_IDENT: ConstIdent = ConstIdent("__entity__");
-/// Ident for the `EntityTree` argument.
-pub(crate) const TREE_IDENT: ConstIdent = ConstIdent("__tree__");
+/// Ident for the `SchematicContext` argument.
+pub(crate) const CONTEXT_IDENT: ConstIdent = ConstIdent("__context__");
 /// Ident for the `DependenciesBuilder` argument.
 pub(crate) const DEPENDENCIES_IDENT: ConstIdent = ConstIdent("__dependencies__");
 

--- a/bevy_proto_derive/src/schematic/input.rs
+++ b/bevy_proto_derive/src/schematic/input.rs
@@ -6,7 +6,7 @@ use to_phantom::ToPhantom;
 
 use crate::schematic::data::SchematicData;
 use crate::schematic::fields::SchematicField;
-use crate::schematic::idents::{ENTITY_IDENT, INPUT_IDENT, TREE_IDENT};
+use crate::schematic::idents::{CONTEXT_IDENT, INPUT_IDENT};
 use crate::schematic::self_type::SelfType;
 use crate::schematic::structs::SchematicStruct;
 use crate::schematic::DeriveSchematic;
@@ -42,14 +42,14 @@ impl InputType {
             (InputType::Reflexive, SelfType::Reflexive) => None,
             (_, SelfType::Into(self_ty)) => Some(quote! {
                 let #INPUT_IDENT = <Self as #proto_crate::schematics::FromSchematicInput<Self::Input>>::from_input(
-                    #INPUT_IDENT, #ENTITY_IDENT, #TREE_IDENT
+                    #INPUT_IDENT, #CONTEXT_IDENT
                 );
                 let #INPUT_IDENT = <#self_ty as #proto_crate::schematics::FromSchematicInput<Self>>::from_input(
-                    #INPUT_IDENT, #ENTITY_IDENT, #TREE_IDENT
+                    #INPUT_IDENT, #CONTEXT_IDENT
                 );
             }),
             _ => Some(quote! {
-                let #INPUT_IDENT = <Self as #proto_crate::schematics::FromSchematicInput<Self::Input>>::from_input(#INPUT_IDENT, #ENTITY_IDENT, #TREE_IDENT);
+                let #INPUT_IDENT = <Self as #proto_crate::schematics::FromSchematicInput<Self::Input>>::from_input(#INPUT_IDENT, #CONTEXT_IDENT);
             }),
         }
     }
@@ -132,8 +132,7 @@ impl<'a> ToTokens for Input<'a> {
                 impl #impl_generics #proto_crate::schematics::FromSchematicInput<#input_ty> for #base_ty #impl_ty_generics #where_clause {
                     fn from_input(
                         #INPUT_IDENT: #input_ty,
-                        #ENTITY_IDENT: &mut #bevy_crate::ecs::world::EntityMut,
-                        #TREE_IDENT: &#proto_crate::tree::EntityTree
+                        #CONTEXT_IDENT: &mut #proto_crate::schematics::SchematicContext
                     ) -> Self {
                         #body
                     }

--- a/bevy_proto_derive/src/schematic/variants.rs
+++ b/bevy_proto_derive/src/schematic/variants.rs
@@ -4,7 +4,7 @@ use syn::Member;
 
 use crate::schematic::field_attributes::{EntityConfig, ReplacementType};
 use crate::schematic::fields::SchematicField;
-use crate::schematic::idents::{DEPENDENCIES_IDENT, ENTITY_IDENT, TREE_IDENT};
+use crate::schematic::idents::{CONTEXT_IDENT, DEPENDENCIES_IDENT};
 use crate::schematic::input::InputType;
 use crate::schematic::structs::SchematicStruct;
 
@@ -145,14 +145,14 @@ impl SchematicVariant {
             ReplacementType::Asset(config) => {
                 if let Some(path) = config.path() {
                     quote!(
-                        #ENTITY_IDENT
+                        #CONTEXT_IDENT
                             .world()
                             .resource::<#bevy_crate::asset::AssetServer>()
                             .load(#path)
                     )
                 } else {
                     quote!(
-                        #ENTITY_IDENT
+                        #CONTEXT_IDENT
                             .world()
                             .resource::<#bevy_crate::asset::AssetServer>()
                             .load(
@@ -164,20 +164,19 @@ impl SchematicVariant {
                 }
             }
             ReplacementType::Entity(EntityConfig::Undefined) => quote! {
-                #TREE_IDENT
+                #CONTEXT_IDENT
                     .find_entity(&#member)
                     .unwrap_or_else(|| panic!("entity should exist at path {:?}", &#member))
             },
             ReplacementType::Entity(EntityConfig::Path(path)) => quote! {
-                #TREE_IDENT
+                #CONTEXT_IDENT
                     .find_entity(&#proto_crate::tree::EntityAccess::from(#path))
                     .unwrap_or_else(|| panic!("entity should exist at path {:?}", #path))
             },
             ReplacementType::From(replacement_ty) => quote! {
                 <#ty as #proto_crate::schematics::FromSchematicInput<#replacement_ty>>::from_input(
                     #member,
-                    #ENTITY_IDENT,
-                    #TREE_IDENT
+                    #CONTEXT_IDENT,
                 )
             },
         }

--- a/examples/basic_schematic.rs
+++ b/examples/basic_schematic.rs
@@ -14,13 +14,17 @@ fn main() {
         .register_type::<Alignment>()
         // If you didn't use `#[reflect(Schematic)]`,
         // you can still register it manually:
-        .register_type::<PlayerHealth>()
-        .register_type_data::<PlayerHealth, ReflectSchematic>()
+        .register_type::<MaxPlayers>()
+        .register_type_data::<MaxPlayers, ReflectSchematic>()
         // =============== //
         .add_plugin(ProtoPlugin::default())
         .add_startup_systems((setup, load))
         .add_systems((
-            spawn.run_if(prototype_ready("Player").and_then(run_once())),
+            spawn.run_if(
+                prototype_ready("Player")
+                    .and_then(prototype_ready("PlayerConfig"))
+                    .and_then(run_once()),
+            ),
             inspect,
         ))
         .run();
@@ -52,29 +56,44 @@ enum Alignment {
 /// The derive macro also has basic support for Bevy resources.
 ///
 /// This can be done by specifying the "kind".
+/// It's also a good idea to set `entity: false` in the prototype file.
 ///
 /// Note that when a schematic is applied, it will replace the current instance
 /// of the resource in the world.
 #[derive(Resource, Schematic, Reflect, FromReflect)]
 #[schematic(kind = "resource")]
-struct PlayerHealth(u16);
+struct MaxPlayers(u8);
 
 fn load(mut prototypes: PrototypesMut) {
     prototypes.load("examples/basic_schematic/Player.prototype.ron");
+    prototypes.load("examples/basic_schematic/PlayerConfig.prototype.ron");
 }
 
 fn spawn(mut commands: ProtoCommands) {
     commands.spawn("Player");
+    // Since this schematic just defines a resource and doesn't need an entity,
+    // we can use `apply` instead of `spawn`.
+    commands.apply("PlayerConfig");
 }
 
 // This relies on the `auto_name` feature to be useful
-fn inspect(query: Query<(DebugName, &Alignment), Added<Playable>>) {
+fn inspect(
+    query: Query<(DebugName, &Alignment), Added<Playable>>,
+    max_players: Option<Res<MaxPlayers>>,
+) {
     for (name, alignment) in &query {
         println!("===============");
         println!("Spawned Player:");
         println!("  ID: {name:?}");
         println!("  Alignment: {alignment:?}");
         println!("===============");
+        match &max_players {
+            Some(max_players) if max_players.is_added() => {
+                println!("Max. Players: {}", max_players.0);
+                println!("===============");
+            }
+            _ => {}
+        }
     }
 }
 

--- a/examples/bevy/ui.rs
+++ b/examples/bevy/ui.rs
@@ -9,7 +9,6 @@
 //!
 //! [`ui`]: https://github.com/bevyengine/bevy/blob/v0.10.1/examples/ui/ui.rs
 
-use bevy::ecs::world::EntityMut;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy_proto::prelude::*;
@@ -71,22 +70,26 @@ fn mouse_scroll(
 impl Schematic for ScrollText {
     type Input = ScrollText;
 
-    fn apply(input: &Self::Input, entity: &mut EntityMut, _tree: &EntityTree) {
-        entity.insert(TextBundle::from_section(
-            input.0.clone(),
-            TextStyle {
-                font: entity
-                    .world()
-                    .resource::<AssetServer>()
-                    .load("fonts/JetBrainsMono-Regular.ttf"),
-                font_size: 20.,
-                color: Color::WHITE,
-            },
-        ));
+    fn apply(input: &Self::Input, context: &mut SchematicContext) {
+        let font = context
+            .world()
+            .resource::<AssetServer>()
+            .load("fonts/JetBrainsMono-Regular.ttf");
+        context
+            .entity_mut()
+            .unwrap()
+            .insert(TextBundle::from_section(
+                input.0.clone(),
+                TextStyle {
+                    font,
+                    font_size: 20.,
+                    color: Color::WHITE,
+                },
+            ));
     }
 
-    fn remove(_input: &Self::Input, entity: &mut EntityMut, _tree: &EntityTree) {
-        entity.remove::<TextBundle>();
+    fn remove(_input: &Self::Input, context: &mut SchematicContext) {
+        context.entity_mut().unwrap().remove::<TextBundle>();
     }
 }
 

--- a/examples/hierarchy.rs
+++ b/examples/hierarchy.rs
@@ -34,15 +34,15 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ProtoPlugin::new(
-            ProtoConfig::default().on_before_apply_prototype(Box::new(|prototype, _, tree| {
+            ProtoConfig::default().on_before_apply_prototype(Box::new(|prototype, context| {
                 // To see the end result of our hierarchy, let's inspect the generated
                 // `EntityTree` for the `Parent` prototype.
                 if prototype.id() == "Parent" {
-                    println!("{:#?}", tree);
+                    println!("{:#?}", context.tree());
 
                     // We can also directly access the generated entities
                     // (check out the docs for `EntityAccess` for details):
-                    let key_entity = tree.find_entity(&EntityAccess::from("/OtherChild/@0"));
+                    let key_entity = context.find_entity(&EntityAccess::from("/OtherChild/@0"));
                     println!("🔑 Key Entity: {:?}", key_entity.unwrap());
                 }
             })),

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,11 @@
 //! [prototypes]: Prototype
 
 use bevy::asset::Handle;
-use bevy::ecs::world::EntityMut;
 use bevy::prelude::Resource;
 
 use bevy_proto_backend::cycles::{Cycle, CycleResponse};
 use bevy_proto_backend::proto::Config;
-use bevy_proto_backend::schematics::DynamicSchematic;
-use bevy_proto_backend::tree::EntityTree;
+use bevy_proto_backend::schematics::{DynamicSchematic, SchematicContext};
 
 use crate::hooks::{
     OnAfterApplyPrototype, OnAfterApplySchematic, OnAfterRemovePrototype, OnAfterRemoveSchematic,
@@ -164,91 +162,71 @@ impl Config<Prototype> for ProtoConfig {
         }
     }
 
-    fn on_before_apply_prototype(
-        &mut self,
-        prototype: &Prototype,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
+    fn on_before_apply_prototype(&mut self, prototype: &Prototype, context: &mut SchematicContext) {
         if let Some(on_before_apply_prototype) = &mut self.on_before_apply_prototype {
-            on_before_apply_prototype(prototype, entity, tree);
+            on_before_apply_prototype(prototype, context);
         }
     }
 
-    fn on_after_apply_prototype(
-        &mut self,
-        prototype: &Prototype,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
+    fn on_after_apply_prototype(&mut self, prototype: &Prototype, context: &mut SchematicContext) {
         if let Some(on_after_apply_prototype) = &mut self.on_after_apply_prototype {
-            on_after_apply_prototype(prototype, entity, tree);
+            on_after_apply_prototype(prototype, context);
         }
     }
 
     fn on_before_remove_prototype(
         &mut self,
         prototype: &Prototype,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
         if let Some(on_before_remove_prototype) = &mut self.on_before_remove_prototype {
-            on_before_remove_prototype(prototype, entity, tree);
+            on_before_remove_prototype(prototype, context);
         }
     }
 
-    fn on_after_remove_prototype(
-        &mut self,
-        prototype: &Prototype,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) {
+    fn on_after_remove_prototype(&mut self, prototype: &Prototype, context: &mut SchematicContext) {
         if let Some(on_after_remove_prototype) = &mut self.on_after_remove_prototype {
-            on_after_remove_prototype(prototype, entity, tree);
+            on_after_remove_prototype(prototype, context);
         }
     }
 
     fn on_before_apply_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
         if let Some(on_before_apply_schematic) = &mut self.on_before_apply_schematic {
-            on_before_apply_schematic(schematic, entity, tree);
+            on_before_apply_schematic(schematic, context);
         }
     }
 
     fn on_after_apply_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
         if let Some(on_after_apply_schematic) = &mut self.on_after_apply_schematic {
-            on_after_apply_schematic(schematic, entity, tree);
+            on_after_apply_schematic(schematic, context);
         }
     }
 
     fn on_before_remove_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
         if let Some(on_before_remove_schematic) = &mut self.on_before_remove_schematic {
-            on_before_remove_schematic(schematic, entity, tree);
+            on_before_remove_schematic(schematic, context);
         }
     }
 
     fn on_after_remove_schematic(
         &mut self,
         schematic: &DynamicSchematic,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
+        context: &mut SchematicContext,
     ) {
         if let Some(on_after_remove_schematic) = &mut self.on_after_remove_schematic {
-            on_after_remove_schematic(schematic, entity, tree);
+            on_after_remove_schematic(schematic, context);
         }
     }
 

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -7,14 +7,14 @@
 
 use bevy::app::App;
 use bevy::asset::Handle;
-use bevy::ecs::world::EntityMut;
 use bevy::prelude::{Component, GlobalTransform, Transform};
 use bevy::reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 use bevy_proto_backend::impls::bevy_impls;
 use bevy_proto_backend::{from, from_to_default, from_to_input};
 
-use bevy_proto_backend::schematics::{FromSchematicInput, ReflectSchematic, Schematic};
-use bevy_proto_backend::tree::EntityTree;
+use bevy_proto_backend::schematics::{
+    FromSchematicInput, ReflectSchematic, Schematic, SchematicContext,
+};
 
 pub(crate) fn register_custom_schematics(app: &mut App) {
     app.register_type::<TransformBundle>();
@@ -481,9 +481,9 @@ pub struct Text2dBundle {
 from_to_input!(
     bevy::text::Text2dBundle,
     Text2dBundle,
-    |input: Input, entity, tree| {
+    |input: Input, context| {
         Self {
-            text: FromSchematicInput::from_input(input.text, entity, tree),
+            text: FromSchematicInput::from_input(input.text, context),
             text_anchor: input.text_anchor,
             text_2d_bounds: input.text_2d_bounds.into(),
             transform: input.transform,
@@ -546,7 +546,7 @@ pub struct ButtonBundle {
 
 #[cfg(feature = "bevy_ui")]
 impl FromSchematicInput<ButtonBundle> for bevy::ui::node_bundles::ButtonBundle {
-    fn from_input(input: ButtonBundle, entity: &mut EntityMut, tree: &EntityTree) -> Self {
+    fn from_input(input: ButtonBundle, context: &mut SchematicContext) -> Self {
         Self {
             node: input.node.into(),
             button: input.button.into(),
@@ -554,7 +554,7 @@ impl FromSchematicInput<ButtonBundle> for bevy::ui::node_bundles::ButtonBundle {
             interaction: input.interaction.into(),
             focus_policy: input.focus_policy.into(),
             background_color: input.background_color.into(),
-            image: bevy::ui::UiImage::from_input(input.image, entity, tree),
+            image: bevy::ui::UiImage::from_input(input.image, context),
             transform: input.transform,
             global_transform: input.global_transform,
             visibility: input.visibility,
@@ -598,13 +598,13 @@ pub struct ImageBundle {
 
 #[cfg(feature = "bevy_ui")]
 impl FromSchematicInput<ImageBundle> for bevy::ui::node_bundles::ImageBundle {
-    fn from_input(input: ImageBundle, entity: &mut EntityMut, tree: &EntityTree) -> Self {
+    fn from_input(input: ImageBundle, context: &mut SchematicContext) -> Self {
         Self {
             node: input.node.into(),
             style: input.style.into(),
             calculated_size: input.calculated_size.into(),
             background_color: input.background_color.into(),
-            image: bevy::ui::UiImage::from_input(input.image, entity, tree),
+            image: bevy::ui::UiImage::from_input(input.image, context),
             focus_policy: input.focus_policy.into(),
             transform: input.transform,
             global_transform: input.global_transform,
@@ -678,11 +678,11 @@ pub struct TextBundle {
 from_to_input!(
     bevy::ui::node_bundles::TextBundle,
     TextBundle,
-    |input: Input, entity, tree| {
+    |input: Input, context| {
         Self {
             node: input.node.into(),
             style: input.style.into(),
-            text: FromSchematicInput::from_input(input.text, entity, tree),
+            text: FromSchematicInput::from_input(input.text, context),
             calculated_size: input.calculated_size.into(),
             focus_policy: input.focus_policy.into(),
             transform: input.transform,
@@ -784,13 +784,9 @@ pub struct MaterialMesh2dBundle<M: bevy::sprite::Material2d> {
 impl<M: bevy::sprite::Material2d> FromSchematicInput<MaterialMesh2dBundle<M>>
     for bevy::sprite::MaterialMesh2dBundle<M>
 {
-    fn from_input(
-        input: MaterialMesh2dBundle<M>,
-        entity: &mut EntityMut,
-        tree: &EntityTree,
-    ) -> Self {
+    fn from_input(input: MaterialMesh2dBundle<M>, context: &mut SchematicContext) -> Self {
         Self {
-            mesh: bevy::sprite::Mesh2dHandle::from_input(input.mesh, entity, tree),
+            mesh: bevy::sprite::Mesh2dHandle::from_input(input.mesh, context),
             material: input.material,
             transform: input.transform,
             global_transform: input.global_transform,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -3,31 +3,25 @@
 //! [config]: crate::config::ProtoConfig
 
 use bevy::asset::Handle;
-use bevy::ecs::world::EntityMut;
 
 use bevy_proto_backend::cycles::{Cycle, CycleResponse};
-use bevy_proto_backend::schematics::DynamicSchematic;
-use bevy_proto_backend::tree::EntityTree;
+use bevy_proto_backend::schematics::{DynamicSchematic, SchematicContext};
 
 use crate::proto::Prototype;
 
 pub type OnRegisterPrototype = Box<dyn FnMut(&Prototype, Handle<Prototype>) + Send + Sync>;
 pub type OnReloadPrototype = Box<dyn FnMut(&Prototype, Handle<Prototype>) + Send + Sync>;
 pub type OnUnregisterPrototype = Box<dyn FnMut(&String, Handle<Prototype>) + Send + Sync>;
-pub type OnBeforeApplyPrototype =
-    Box<dyn FnMut(&Prototype, &mut EntityMut, &EntityTree) + Send + Sync>;
-pub type OnAfterApplyPrototype =
-    Box<dyn FnMut(&Prototype, &mut EntityMut, &EntityTree) + Send + Sync>;
-pub type OnBeforeRemovePrototype =
-    Box<dyn FnMut(&Prototype, &mut EntityMut, &EntityTree) + Send + Sync>;
-pub type OnAfterRemovePrototype =
-    Box<dyn FnMut(&Prototype, &mut EntityMut, &EntityTree) + Send + Sync>;
+pub type OnBeforeApplyPrototype = Box<dyn FnMut(&Prototype, &mut SchematicContext) + Send + Sync>;
+pub type OnAfterApplyPrototype = Box<dyn FnMut(&Prototype, &mut SchematicContext) + Send + Sync>;
+pub type OnBeforeRemovePrototype = Box<dyn FnMut(&Prototype, &mut SchematicContext) + Send + Sync>;
+pub type OnAfterRemovePrototype = Box<dyn FnMut(&Prototype, &mut SchematicContext) + Send + Sync>;
 pub type OnBeforeApplySchematic =
-    Box<dyn FnMut(&DynamicSchematic, &mut EntityMut, &EntityTree) + Send + Sync>;
+    Box<dyn FnMut(&DynamicSchematic, &mut SchematicContext) + Send + Sync>;
 pub type OnAfterApplySchematic =
-    Box<dyn FnMut(&DynamicSchematic, &mut EntityMut, &EntityTree) + Send + Sync>;
+    Box<dyn FnMut(&DynamicSchematic, &mut SchematicContext) + Send + Sync>;
 pub type OnBeforeRemoveSchematic =
-    Box<dyn FnMut(&DynamicSchematic, &mut EntityMut, &EntityTree) + Send + Sync>;
+    Box<dyn FnMut(&DynamicSchematic, &mut SchematicContext) + Send + Sync>;
 pub type OnAfterRemoveSchematic =
-    Box<dyn FnMut(&DynamicSchematic, &mut EntityMut, &EntityTree) + Send + Sync>;
+    Box<dyn FnMut(&DynamicSchematic, &mut SchematicContext) + Send + Sync>;
 pub type OnCycle = Box<dyn Fn(&Cycle<Prototype>) -> CycleResponse + Send + Sync>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,7 @@ mod schematics;
 pub mod prelude {
     pub use bevy_proto_backend::deps::DependenciesBuilder;
     pub use bevy_proto_backend::proto::Prototypical;
-    pub use bevy_proto_backend::schematics::{ReflectSchematic, Schematic};
-    pub use bevy_proto_backend::tree::EntityTree;
+    pub use bevy_proto_backend::schematics::{ReflectSchematic, Schematic, SchematicContext};
 
     pub use super::conditions::*;
     pub use super::plugin::ProtoPlugin;

--- a/src/proto/prototype.rs
+++ b/src/proto/prototype.rs
@@ -18,6 +18,7 @@ use crate::proto::{ProtoChild, PrototypeDeserializer, PrototypeError};
 pub struct Prototype {
     pub(crate) id: String,
     pub(crate) path: ProtoPath,
+    pub(crate) requires_entity: bool,
     pub(crate) schematics: Schematics,
     pub(crate) templates: Option<Templates>,
     pub(crate) dependencies: Dependencies,
@@ -36,6 +37,10 @@ impl Prototypical for Prototype {
 
     fn path(&self) -> &ProtoPath {
         &self.path
+    }
+
+    fn requires_entity(&self) -> bool {
+        self.requires_entity
     }
 
     fn schematics(&self) -> &Schematics {


### PR DESCRIPTION
## Added

- Added `Prototypical::requires_entity` method to signal that an entity does not need to be spawned for a prototype
  -  Represented by the `entity` field in the prototype format
- Added `SchematicContext` to contain contextual `Schematic`-related data

## Changed

- Changed signatures of `Schematic::apply`, `Schematic::remove`, `FromSchematicInput::from_input` (and all corresponding types)
  - Replaced `&mut EntityMut, &EntityTree` with `&mut SchematicContext`