### PR TITLE
Add PrototypesMut::load_folder

### DIFF
--- a/bevy_proto_backend/src/path/error.rs
+++ b/bevy_proto_backend/src/path/error.rs
@@ -27,4 +27,7 @@ pub enum PathError {
     /// [`Config`]: crate::proto::Config
     #[error("invalid extension {0:?}")]
     InvalidExtension(PathBuf),
+    /// The path cannot be converted to a string.
+    #[error("cannot convert path to a string")]
+    ConversionError
 }

--- a/bevy_proto_backend/src/path/error.rs
+++ b/bevy_proto_backend/src/path/error.rs
@@ -27,7 +27,4 @@ pub enum PathError {
     /// [`Config`]: crate::proto::Config
     #[error("invalid extension {0:?}")]
     InvalidExtension(PathBuf),
-    /// The path cannot be converted to a string.
-    #[error("cannot convert path to a string")]
-    ConversionError
 }

--- a/bevy_proto_backend/src/proto/prototypes.rs
+++ b/bevy_proto_backend/src/proto/prototypes.rs
@@ -1,11 +1,11 @@
 use std::borrow::{Borrow, Cow};
 
+use crate::path::PathError;
 use bevy::asset::{AssetServerError, Handle, HandleId, HandleUntyped, LoadState};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::{AssetServer, Res, ResMut};
 use std::hash::Hash;
 use thiserror::Error;
-use crate::path::PathError;
 
 use crate::proto::{ProtoStorage, Prototypical};
 use crate::registration::ProtoRegistry;
@@ -65,12 +65,16 @@ impl<'w, T: Prototypical> PrototypesMut<'w, T> {
     /// This will also store strong handles to the prototypes in order to keep them loaded.
     ///
     /// To load without automatically storing the handles, try using [`AssetServer::load_folder`].
-    pub fn load_folder<P: Into<Cow<'static, str>>>(&mut self, path: P) -> Result<Vec<HandleUntyped>, ProtoLoadError> {
+    pub fn load_folder<P: Into<Cow<'static, str>>>(
+        &mut self,
+        path: P,
+    ) -> Result<Vec<HandleUntyped>, ProtoLoadError> {
         let path = path.into();
         let handles: Vec<_> = self.asset_server.load_folder(path.as_ref())?;
 
         for handle in &handles {
-            let path = self.asset_server
+            let path = self
+                .asset_server
                 .get_handle_path(handle)
                 .unwrap()
                 .path()

--- a/bevy_proto_backend/src/proto/prototypes.rs
+++ b/bevy_proto_backend/src/proto/prototypes.rs
@@ -1,12 +1,24 @@
 use std::borrow::{Borrow, Cow};
 
-use bevy::asset::{AssetServerError, Handle, HandleId, LoadState};
+use bevy::asset::{AssetServerError, Handle, HandleId, HandleUntyped, LoadState};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::{AssetServer, Res, ResMut};
 use std::hash::Hash;
+use thiserror::Error;
+use crate::path::PathError;
 
 use crate::proto::{ProtoStorage, Prototypical};
 use crate::registration::ProtoRegistry;
+
+#[derive(Debug, Error)]
+pub enum ProtoLoadError {
+    /// Indicates that the [`AssetServer`] encountered an error.
+    #[error(transparent)]
+    AssetServerError(#[from] AssetServerError),
+    /// Indicates that there was a path error.
+    #[error(transparent)]
+    PathError(#[from] PathError),
+}
 
 /// A helper [`SystemParam`] for managing [prototypes].
 ///
@@ -48,21 +60,26 @@ impl<'w, T: Prototypical> PrototypesMut<'w, T> {
         handle
     }
 
-    /// Load the prototypes at the given path.
+    /// Load all the prototypes in the given directory.
     ///
     /// This will also store strong handles to the prototypes in order to keep them loaded.
     ///
     /// To load without automatically storing the handles, try using [`AssetServer::load_folder`].
-    pub fn load_folder<P: Into<Cow<'static, str>>>(&mut self, path: P) -> Result<Vec<Handle<T>>, AssetServerError> {
+    pub fn load_folder<P: Into<Cow<'static, str>>>(&mut self, path: P) -> Result<Vec<HandleUntyped>, ProtoLoadError> {
         let path = path.into();
-        let handles: Vec<_> = self.asset_server.load_folder(path.as_ref())?
-            .into_iter().map(|handle| handle.typed::<T>()).collect();
+        let handles: Vec<_> = self.asset_server.load_folder(path.as_ref())?;
 
-        handles.iter().for_each(|handle| {
-            let path = self.asset_server.get_handle_path(handle).unwrap().path().to_str().unwrap().to_string();
+        for handle in &handles {
+            let path = self.asset_server
+                .get_handle_path(handle)
+                .unwrap()
+                .path()
+                .to_str()
+                .ok_or(PathError::ConversionError)?
+                .to_string();
 
-            self.storage.insert(path, handle.clone());
-        });
+            self.storage.insert(path, handle.clone().typed::<T>());
+        }
 
         Ok(handles)
     }

--- a/bevy_proto_backend/src/proto/storage.rs
+++ b/bevy_proto_backend/src/proto/storage.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
 use bevy::asset::Handle;
 use bevy::prelude::Resource;
@@ -11,20 +11,20 @@ use crate::proto::Prototypical;
 /// [prototype]: Prototypical
 #[derive(Resource)]
 pub(crate) struct ProtoStorage<T: Prototypical> {
-    path_to_handle: HashMap<Cow<'static, str>, Handle<T>>,
+    path_to_handle: HashMap<PathBuf, Handle<T>>,
 }
 
 impl<T: Prototypical> ProtoStorage<T> {
     /// Returns true if a prototype with the given path is currently stored in this resource.
-    pub fn contains(&self, path: &str) -> bool {
-        self.path_to_handle.contains_key(path)
+    pub fn contains<P: AsRef<Path>>(&self, path: P) -> bool {
+        self.path_to_handle.contains_key(path.as_ref())
     }
 
     /// Get a reference to the strong handle for the prototype at the given path.
     ///
     /// Returns `None` if no matching prototype is currently stored in this resource.
-    pub fn get(&self, path: &str) -> Option<&Handle<T>> {
-        self.path_to_handle.get(path)
+    pub fn get<P: AsRef<Path>>(&self, path: P) -> Option<&Handle<T>> {
+        self.path_to_handle.get(path.as_ref())
     }
 
     /// Insert a prototype handle into this resource for the given path.
@@ -34,18 +34,14 @@ impl<T: Prototypical> ProtoStorage<T> {
     /// # Panics
     ///
     /// Panics if the given handle is weak.
-    pub fn insert<P: Into<Cow<'static, str>>>(
-        &mut self,
-        path: P,
-        handle: Handle<T>,
-    ) -> Option<Handle<T>> {
+    pub fn insert<P: Into<PathBuf>>(&mut self, path: P, handle: Handle<T>) -> Option<Handle<T>> {
         debug_assert!(handle.is_strong(), "attempted to store weak handle");
         self.path_to_handle.insert(path.into(), handle)
     }
 
     /// Remove the handle with the given path.
-    pub fn remove(&mut self, path: &str) -> Option<Handle<T>> {
-        self.path_to_handle.remove(path)
+    pub fn remove<P: AsRef<Path>>(&mut self, path: P) -> Option<Handle<T>> {
+        self.path_to_handle.remove(path.as_ref())
     }
 
     /// Remove all handles.


### PR DESCRIPTION
Add `PrototypesMut::load_folder` so that it mirrors `AssetServer::load_folder`, with the exception that the returned handles are typed.