### PR TITLE
Correctly handle `ProtoAsset::HandleId`

### DIFF
--- a/bevy_proto_derive/src/schematic/fields.rs
+++ b/bevy_proto_derive/src/schematic/fields.rs
@@ -88,15 +88,20 @@ impl SchematicField {
                     )
                 } else {
                     quote!(
-                        #CONTEXT_IDENT
-                            .world()
-                            .resource::<#bevy_crate::asset::AssetServer>()
-                            .load(
-                                #INPUT_IDENT
-                                    .#member
-                                    .to_asset_path()
-                                    .expect("ProtoAsset should contain an asset path")
-                            )
+                        match #INPUT_IDENT.#member {
+                            #proto_crate::proto::ProtoAsset::AssetPath(ref path) => {
+                                #CONTEXT_IDENT
+                                    .world()
+                                    .resource::<#bevy_crate::asset::AssetServer>()
+                                    .load(path)
+                            }
+                            #proto_crate::proto::ProtoAsset::HandleId(handle_id) => {
+                                #CONTEXT_IDENT
+                                    .world()
+                                    .resource::<#bevy_crate::asset::AssetServer>()
+                                    .get_handle(handle_id)
+                            }
+                        }
                     )
                 }
             }

--- a/examples/derive_schematic.rs
+++ b/examples/derive_schematic.rs
@@ -73,6 +73,16 @@ struct Foo<T: Reflect> {
     _phantom: PhantomData<T>,
 }
 
+#[derive(Component, Schematic, Reflect)]
+#[reflect(Schematic)]
+enum Foob {
+    Bar(#[schematic(asset(preload))] Handle<Image>),
+    Baz {
+        #[schematic(asset(preload))]
+        image: Handle<Image>,
+    },
+}
+
 #[derive(Reflect, FromReflect)]
 struct EntityGroup(Vec<Entity>);
 

--- a/tests/compile_tests/generics.pass.rs
+++ b/tests/compile_tests/generics.pass.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 #[derive(Component, Schematic, Reflect)]
 #[reflect(Schematic)]
 struct TupleStructWithGenerics<'a: 'static, T: Asset, const N: usize>(
-    #[schematic(asset)] Handle<T>,
+    #[schematic(asset(preload))] Handle<T>,
     Cow<'a, str>,
     [i32; N],
 );
@@ -14,7 +14,7 @@ struct TupleStructWithGenerics<'a: 'static, T: Asset, const N: usize>(
 #[derive(Component, Schematic, Reflect)]
 #[reflect(Schematic)]
 struct StructWithGenerics<'a: 'static, T: Asset, const N: usize> {
-    #[schematic(asset)]
+    #[schematic(asset(preload))]
     asset: Handle<T>,
     string: Cow<'a, str>,
     array: [i32; N],
@@ -24,9 +24,13 @@ struct StructWithGenerics<'a: 'static, T: Asset, const N: usize> {
 #[reflect(Schematic)]
 enum EnumWithGenerics<'a: 'static, T: Asset, const N: usize> {
     Unit,
-    Tuple(#[schematic(asset)] Handle<T>, Cow<'a, str>, [i32; N]),
+    Tuple(
+        #[schematic(asset(preload))] Handle<T>,
+        Cow<'a, str>,
+        [i32; N],
+    ),
     Struct {
-        #[schematic(asset)]
+        #[schematic(asset(preload))]
         asset: Handle<T>,
         string: Cow<'a, str>,
         array: [i32; N],


### PR DESCRIPTION
#33 added `ProtoAsset::HandleId`. The main purpose of this was to allow for default `ProtoAsset` values using `Handle<T>::default()`.

However, the derive macro failed to account for this properly, resulting in a panic when attempting to spawn the prototype.

The behavior of preloading a `ProtoAsset::HandleId` is correct— we should not be able to preload anything just by its `HandleId`. This PR just makes the error message a little clearer.