### PR TITLE
Add `schematic_attr` for forwarding attributes

### DIFF
--- a/bevy_proto_derive/src/asset_schematic/container_attributes.rs
+++ b/bevy_proto_derive/src/asset_schematic/container_attributes.rs
@@ -1,7 +1,9 @@
 use syn::{Attribute, Error};
 
-use crate::common::input::{parse_input_meta, InputType, OutputType, SchematicIo};
-use crate::utils::constants::{ASSET_SCHEMATIC_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR};
+use crate::common::input::{
+    parse_input_meta, ForwardAttributes, InputType, OutputType, SchematicIo,
+};
+use crate::utils::constants::{ASSET_SCHEMATIC_ATTR, ATTR_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR};
 use crate::utils::{
     define_attribute, parse_bool, parse_nested_meta, AttrArg, AttrArgValue, AttrTarget,
 };
@@ -12,6 +14,7 @@ define_attribute!("no_preload" => NoPreloadArg(bool) for AttrTarget::Asset);
 #[derive(Default)]
 pub(super) struct ContainerAttributes {
     no_preload: NoPreloadArg,
+    forward_attrs: ForwardAttributes,
 }
 
 impl ContainerAttributes {
@@ -28,6 +31,7 @@ impl ContainerAttributes {
                 INTO_ATTR => io.try_set_output_ty(OutputType::Custom(meta.value()?.parse()?), None),
                 INPUT_ATTR => parse_input_meta(meta, io),
                 NoPreloadArg::NAME => this.no_preload.try_set(Some(parse_bool(&meta)?), meta.input.span()),
+                ATTR_ATTR => this.forward_attrs.extend_from_nested_meta(meta),
             })?;
         }
 
@@ -36,5 +40,9 @@ impl ContainerAttributes {
 
     pub fn no_preload(&self) -> bool {
         self.no_preload.get().copied().unwrap_or_default()
+    }
+
+    pub fn forward_attrs(&self) -> &ForwardAttributes {
+        &self.forward_attrs
     }
 }

--- a/bevy_proto_derive/src/asset_schematic/container_attributes.rs
+++ b/bevy_proto_derive/src/asset_schematic/container_attributes.rs
@@ -3,7 +3,9 @@ use syn::{Attribute, Error};
 use crate::common::input::{
     parse_input_meta, ForwardAttributes, InputType, OutputType, SchematicIo,
 };
-use crate::utils::constants::{ASSET_SCHEMATIC_ATTR, ATTR_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR};
+use crate::utils::constants::{
+    ASSET_SCHEMATIC_ATTR, ASSET_SCHEMATIC_ATTR_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR,
+};
 use crate::utils::{
     define_attribute, parse_bool, parse_nested_meta, AttrArg, AttrArgValue, AttrTarget,
 };
@@ -22,6 +24,11 @@ impl ContainerAttributes {
         let mut this = Self::default();
 
         for attr in attrs {
+            if attr.path().is_ident(ASSET_SCHEMATIC_ATTR_ATTR) {
+                this.forward_attrs.extend_from_attribute(attr)?;
+                continue;
+            }
+
             if !attr.path().is_ident(ASSET_SCHEMATIC_ATTR) {
                 continue;
             }
@@ -31,7 +38,6 @@ impl ContainerAttributes {
                 INTO_ATTR => io.try_set_output_ty(OutputType::Custom(meta.value()?.parse()?), None),
                 INPUT_ATTR => parse_input_meta(meta, io),
                 NoPreloadArg::NAME => this.no_preload.try_set(Some(parse_bool(&meta)?), meta.input.span()),
-                ATTR_ATTR => this.forward_attrs.extend_from_nested_meta(meta),
             })?;
         }
 

--- a/bevy_proto_derive/src/asset_schematic/derive.rs
+++ b/bevy_proto_derive/src/asset_schematic/derive.rs
@@ -86,6 +86,7 @@ impl DeriveAssetSchematic {
             self.io(),
             self.data(),
             self.generics(),
+            self.attrs.forward_attrs(),
             self.attrs().no_preload(),
         )?;
         let load_def = self.load_def();

--- a/bevy_proto_derive/src/common/fields/schematic_fields.rs
+++ b/bevy_proto_derive/src/common/fields/schematic_fields.rs
@@ -4,12 +4,15 @@ use crate::common::fields::{
     OptionalArg, SchematicField,
 };
 use crate::common::input::{InputType, SchematicIo};
-use crate::utils::constants::{ASSET_ATTR, ATTR_ATTR, ENTITY_ATTR, FROM_ATTR};
+use crate::utils::constants::{
+    ASSET_ATTR, ASSET_SCHEMATIC_ATTR, ASSET_SCHEMATIC_ATTR_ATTR, ENTITY_ATTR, FROM_ATTR,
+    SCHEMATIC_ATTR, SCHEMATIC_ATTR_ATTR,
+};
 use crate::utils::{parse_bool, parse_nested_meta, AttrArg};
 use proc_macro2::Span;
 use syn::meta::ParseNestedMeta;
 use syn::spanned::Spanned;
-use syn::{Error, Field, Fields, Type};
+use syn::{Attribute, Error, Field, Fields, Type};
 
 /// The collection of fields for a struct or enum.
 pub(crate) enum SchematicFields {
@@ -71,26 +74,39 @@ struct ProtoFieldBuilder<'a> {
 impl<'a> ProtoFieldBuilder<'a> {
     fn build(mut self) -> Result<SchematicField, Error> {
         for attr in &self.field.attrs {
-            if !attr.path().is_ident(self.derive_type.attr_name()) {
-                continue;
-            }
-
             match self.derive_type {
                 DeriveType::Schematic => {
+                    if attr.path().is_ident(SCHEMATIC_ATTR_ATTR) {
+                        self.parse_forwarded_attr(attr)?;
+                        continue;
+                    }
+
+                    if !attr.path().is_ident(SCHEMATIC_ATTR) {
+                        continue;
+                    }
+
                     parse_nested_meta!(attr, |meta| {
                         FROM_ATTR => self.parse_from_meta(meta),
                         ASSET_ATTR => self.parse_asset_meta(meta),
                         ENTITY_ATTR => self.parse_entity_meta(meta),
                         OptionalArg::NAME => self.parse_optional_meta(meta),
-                        ATTR_ATTR => self.parse_forwarded_attr_meta(meta),
                     })?;
                 }
                 DeriveType::AssetSchematic => {
+                    if attr.path().is_ident(ASSET_SCHEMATIC_ATTR_ATTR) {
+                        self.parse_forwarded_attr(attr)?;
+                        continue;
+                    }
+
+                    if !attr.path().is_ident(ASSET_SCHEMATIC_ATTR) {
+                        continue;
+                    }
+
                     parse_nested_meta!(attr, |meta| {
                         FROM_ATTR => self.parse_from_meta(meta),
                         ASSET_ATTR => self.parse_asset_meta(meta),
+                        ENTITY_ATTR => self.parse_entity_meta(meta),
                         OptionalArg::NAME => self.parse_optional_meta(meta),
-                        ATTR_ATTR => self.parse_forwarded_attr_meta(meta),
                     })?;
                 }
             }
@@ -201,13 +217,11 @@ impl<'a> ProtoFieldBuilder<'a> {
             .try_set_optional(parse_bool(&meta)?, meta.input.span())
     }
 
-    /// Parse a `#[schematic(attr)]` attribute.
-    ///
-    /// This takes in the meta starting at `attr`.
-    fn parse_forwarded_attr_meta(&mut self, meta: ParseNestedMeta) -> Result<(), Error> {
+    /// Parse a `#[schematic_attr]` attribute.
+    fn parse_forwarded_attr(&mut self, attr: &Attribute) -> Result<(), Error> {
         self.proto_field
             .forward_attrs_mut()
-            .extend_from_nested_meta(meta)
+            .extend_from_attribute(attr)
     }
 
     /// Method used to require that a `Schematic::Input` type be generated for the attribute

--- a/bevy_proto_derive/src/common/input/attr.rs
+++ b/bevy_proto_derive/src/common/input/attr.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 use syn::meta::ParseNestedMeta;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, Error, Meta, Token, Visibility};
+use syn::{Attribute, Error, Meta, Token, Visibility};
 
 define_attribute!("vis" => InputVisArg(Visibility) for AttrTarget::InputVisibility, no_debug);
 define_attribute!("name" => InputNameArg(Ident) for AttrTarget::Input);
@@ -39,12 +39,9 @@ pub(crate) struct ForwardAttributes {
 }
 
 impl ForwardAttributes {
-    pub fn extend_from_nested_meta(&mut self, meta: ParseNestedMeta) -> syn::Result<()> {
-        let buffer;
-        parenthesized!(buffer in meta.input);
-
-        let other = buffer.parse::<Self>()?;
-        self.attributes.extend(other.attributes);
+    pub fn extend_from_attribute(&mut self, attr: &Attribute) -> syn::Result<()> {
+        let other = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+        self.attributes.extend(other);
 
         Ok(())
     }

--- a/bevy_proto_derive/src/common/input/attr.rs
+++ b/bevy_proto_derive/src/common/input/attr.rs
@@ -1,11 +1,13 @@
 use crate::common::input::{InputType, SchematicIo};
 use crate::utils::parse_nested_meta;
 use crate::utils::{define_attribute, AttrArg, AttrTarget};
-use proc_macro2::Ident;
-use quote::ToTokens;
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
 use std::fmt::{Debug, Formatter};
 use syn::meta::ParseNestedMeta;
-use syn::{Error, Visibility};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{parenthesized, Error, Meta, Token, Visibility};
 
 define_attribute!("vis" => InputVisArg(Visibility) for AttrTarget::InputVisibility, no_debug);
 define_attribute!("name" => InputNameArg(Ident) for AttrTarget::Input);
@@ -29,4 +31,42 @@ pub(crate) fn parse_input_meta(meta: ParseNestedMeta, io: &mut SchematicIo) -> R
         InputVisArg::NAME => io.try_set_input_vis(meta.value()?.parse()?, None),
         InputNameArg::NAME => io.try_set_input_ty(InputType::Generated(meta.value()?.parse()?), None),
     })
+}
+
+#[derive(Default)]
+pub(crate) struct ForwardAttributes {
+    attributes: Punctuated<Meta, Token![,]>,
+}
+
+impl ForwardAttributes {
+    pub fn extend_from_nested_meta(&mut self, meta: ParseNestedMeta) -> syn::Result<()> {
+        let buffer;
+        parenthesized!(buffer in meta.input);
+
+        let other = buffer.parse::<Self>()?;
+        self.attributes.extend(other.attributes);
+
+        Ok(())
+    }
+}
+
+impl Parse for ForwardAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            attributes: input.parse_terminated(Meta::parse, Token![,])?,
+        })
+    }
+}
+
+impl ToTokens for ForwardAttributes {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if self.attributes.is_empty() {
+            return;
+        }
+
+        let meta = self.attributes.iter();
+        tokens.extend(quote! {
+            #(#[ #meta ])*
+        })
+    }
 }

--- a/bevy_proto_derive/src/common/input/generate.rs
+++ b/bevy_proto_derive/src/common/input/generate.rs
@@ -5,7 +5,7 @@ use to_phantom::ToPhantom;
 
 use crate::common::data::{SchematicData, SchematicVariant};
 use crate::common::fields::{SchematicField, SchematicFields};
-use crate::common::input::{InputType, SchematicIo};
+use crate::common::input::{ForwardAttributes, InputType, SchematicIo};
 use crate::utils::constants::{CONTEXT_IDENT, DEPENDENCIES_IDENT, ID_IDENT, INPUT_IDENT};
 use crate::utils::exports::{
     DependenciesBuilder, FromSchematicInput, FromSchematicPreloadInput, Reflect, SchematicContext,
@@ -17,6 +17,7 @@ pub(crate) fn generate_input(
     io: &SchematicIo,
     data: &SchematicData,
     generics: &Generics,
+    attributes: &ForwardAttributes,
     no_preload: bool,
 ) -> Result<Option<TokenStream>, Error> {
     let input_ident = match io.input_ty() {
@@ -72,6 +73,7 @@ pub(crate) fn generate_input(
 
             Some(quote! {
                 #[derive(#Reflect)]
+                #attributes
                 #vis struct #input_ty_def #where_clause;
 
                 #from_impl
@@ -116,6 +118,7 @@ pub(crate) fn generate_input(
 
             Some(quote! {
                 #[derive(#Reflect)]
+                #attributes
                 #vis struct #input_ty_def (
                     #(#definitions,)*
                     #phantom_ty
@@ -168,6 +171,7 @@ pub(crate) fn generate_input(
 
             Some(quote! {
                 #[derive(#Reflect)]
+                #attributes
                 #vis struct #input_ty_def #where_clause {
                     #(#definitions,)*
                     #phantom_ty
@@ -213,6 +217,7 @@ pub(crate) fn generate_input(
 
             Some(quote! {
                 #[derive(#Reflect)]
+                #attributes
                 #vis enum #input_ty_def #where_clause {
                     #(#definitions,)*
                     #phantom_ty

--- a/bevy_proto_derive/src/lib.rs
+++ b/bevy_proto_derive/src/lib.rs
@@ -73,12 +73,12 @@ mod utils;
 /// - `From<CustomSchematic> for ExternalType`
 /// - `FromSchematicInput<CustomSchematic> for ExternalType`
 ///
-/// ### `#[schematic(attr)]`
+/// ### `#[schematic_attr]`
 ///
 /// This attribute is used to forward attributes to the generated input type,
 /// if one is generated.
 ///
-/// For example, we can add derives on the input type like `#[schematic(attr(derive(Clone, Debug)))]`.
+/// For example, we can add derives on the input type like `#[schematic_attr(derive(Clone, Debug))]`.
 ///
 /// ## Field Attributes
 ///
@@ -186,13 +186,13 @@ mod utils;
 ///
 /// It can also be used to opt-out by specifying `#[schematic(optional = false)]`.
 ///
-/// ### `#[schematic(attr)]`
+/// ### `#[schematic_attr]`
 ///
 /// This attribute is used to forward attributes to the corresponding field on the generated input type,
 /// if one is generated.
 ///
-/// This is useful for passing things like `#[schematic(attr(reflect(ignore)))]`.
-#[proc_macro_derive(Schematic, attributes(schematic))]
+/// This is useful for passing things like `#[schematic_attr(reflect(ignore))]`.
+#[proc_macro_derive(Schematic, attributes(schematic, schematic_attr))]
 pub fn derive_schematic(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveSchematic);
     input.into_token_stream().into()

--- a/bevy_proto_derive/src/lib.rs
+++ b/bevy_proto_derive/src/lib.rs
@@ -18,16 +18,6 @@ mod utils;
 ///
 /// # Attributes
 ///
-/// ## Reflection Attributes
-///
-/// Because this derive macro might generate a custom input type that also relies on reflection,
-/// any reflection attributes on a _field_ are included on the generated field.
-///
-/// For example, adding `#[reflect(default)]` to a field will have it also have the generated
-/// input's field be marked with `#[reflect(default)]`.
-///
-/// This, of course, only applies when an input actually needs to be generated.
-///
 /// ## Container Attributes
 ///
 /// ### `#[schematic(kind = {"resource"|"bundle"})]`
@@ -82,6 +72,13 @@ mod utils;
 /// For this to work, one of the following traits must be satisfied:
 /// - `From<CustomSchematic> for ExternalType`
 /// - `FromSchematicInput<CustomSchematic> for ExternalType`
+///
+/// ### `#[schematic(attr)]`
+///
+/// This attribute is used to forward attributes to the generated input type,
+/// if one is generated.
+///
+/// For example, we can add derives on the input type like `#[schematic(attr(derive(Clone, Debug)))]`.
 ///
 /// ## Field Attributes
 ///
@@ -188,6 +185,13 @@ mod utils;
 /// If this fails, this attribute can be used to force the field to be optional.
 ///
 /// It can also be used to opt-out by specifying `#[schematic(optional = false)]`.
+///
+/// ### `#[schematic(attr)]`
+///
+/// This attribute is used to forward attributes to the corresponding field on the generated input type,
+/// if one is generated.
+///
+/// This is useful for passing things like `#[schematic(attr(reflect(ignore)))]`.
 #[proc_macro_derive(Schematic, attributes(schematic))]
 pub fn derive_schematic(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveSchematic);

--- a/bevy_proto_derive/src/schematic/container_attributes.rs
+++ b/bevy_proto_derive/src/schematic/container_attributes.rs
@@ -3,7 +3,9 @@ use std::fmt::{Debug, Formatter};
 use crate::common::input::{
     parse_input_meta, ForwardAttributes, InputType, OutputType, SchematicIo,
 };
-use crate::utils::constants::{ATTR_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR, SCHEMATIC_ATTR};
+use crate::utils::constants::{
+    FROM_ATTR, INPUT_ATTR, INTO_ATTR, SCHEMATIC_ATTR, SCHEMATIC_ATTR_ATTR,
+};
 use syn::meta::ParseNestedMeta;
 use syn::{Attribute, Error, LitStr};
 
@@ -25,6 +27,11 @@ impl ContainerAttributes {
         let mut this = Self::default();
 
         for attr in attrs {
+            if attr.path().is_ident(SCHEMATIC_ATTR_ATTR) {
+                this.forward_attrs.extend_from_attribute(attr)?;
+                continue;
+            }
+
             if !attr.path().is_ident(SCHEMATIC_ATTR) {
                 continue;
             }
@@ -34,7 +41,6 @@ impl ContainerAttributes {
                 INTO_ATTR => io.try_set_output_ty(OutputType::Custom(meta.value()?.parse()?), None),
                 INPUT_ATTR => parse_input_meta(meta, io),
                 KIND_ATTR => this.parse_kind_meta(meta),
-                ATTR_ATTR => this.forward_attrs.extend_from_nested_meta(meta),
             })?;
         }
 

--- a/bevy_proto_derive/src/schematic/container_attributes.rs
+++ b/bevy_proto_derive/src/schematic/container_attributes.rs
@@ -1,7 +1,9 @@
 use std::fmt::{Debug, Formatter};
 
-use crate::common::input::{parse_input_meta, InputType, OutputType, SchematicIo};
-use crate::utils::constants::{FROM_ATTR, INPUT_ATTR, INTO_ATTR, SCHEMATIC_ATTR};
+use crate::common::input::{
+    parse_input_meta, ForwardAttributes, InputType, OutputType, SchematicIo,
+};
+use crate::utils::constants::{ATTR_ATTR, FROM_ATTR, INPUT_ATTR, INTO_ATTR, SCHEMATIC_ATTR};
 use syn::meta::ParseNestedMeta;
 use syn::{Attribute, Error, LitStr};
 
@@ -15,6 +17,7 @@ const KIND_RESOURCE: &str = "resource";
 #[derive(Default)]
 pub(super) struct ContainerAttributes {
     kind: SchematicKind,
+    forward_attrs: ForwardAttributes,
 }
 
 impl ContainerAttributes {
@@ -31,6 +34,7 @@ impl ContainerAttributes {
                 INTO_ATTR => io.try_set_output_ty(OutputType::Custom(meta.value()?.parse()?), None),
                 INPUT_ATTR => parse_input_meta(meta, io),
                 KIND_ATTR => this.parse_kind_meta(meta),
+                ATTR_ATTR => this.forward_attrs.extend_from_nested_meta(meta),
             })?;
         }
 
@@ -63,6 +67,10 @@ impl ContainerAttributes {
             }
             _ => Err(unsupported_arg(&meta, Some(&[KIND_BUNDLE, KIND_RESOURCE]))),
         }
+    }
+
+    pub fn forward_attrs(&self) -> &ForwardAttributes {
+        &self.forward_attrs
     }
 }
 

--- a/bevy_proto_derive/src/schematic/derive.rs
+++ b/bevy_proto_derive/src/schematic/derive.rs
@@ -113,7 +113,13 @@ impl DeriveSchematic {
         let ident: &Ident = self.io.ident();
         let (impl_generics, ty_generics, where_clause) = self.generics().split_for_impl();
 
-        let input = generate_input(self.io(), self.data(), self.generics(), true)?;
+        let input = generate_input(
+            self.io(),
+            self.data(),
+            self.generics(),
+            self.attrs.forward_attrs(),
+            true,
+        )?;
         let apply_def = self.apply_def();
         let remove_def = self.remove_def();
         let preload_def = self.preload_def()?;

--- a/bevy_proto_derive/src/utils/constants.rs
+++ b/bevy_proto_derive/src/utils/constants.rs
@@ -15,6 +15,7 @@ pub(crate) const ENTITY_ATTR: &str = "entity";
 pub(crate) const INPUT_ATTR: &str = "input";
 pub(crate) const FROM_ATTR: &str = "from";
 pub(crate) const INTO_ATTR: &str = "into";
+pub(crate) const ATTR_ATTR: &str = "attr";
 
 /// Ident for the `Schematic::Input` argument.
 pub(crate) const INPUT_IDENT: ConstIdent = ConstIdent("__input__");

--- a/bevy_proto_derive/src/utils/constants.rs
+++ b/bevy_proto_derive/src/utils/constants.rs
@@ -8,14 +8,15 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
 
 pub(crate) const SCHEMATIC_ATTR: &str = "schematic";
+pub(crate) const SCHEMATIC_ATTR_ATTR: &str = "schematic_attr";
 pub(crate) const ASSET_SCHEMATIC_ATTR: &str = "asset_schematic";
+pub(crate) const ASSET_SCHEMATIC_ATTR_ATTR: &str = "asset_schematic_attr";
 
 pub(crate) const ASSET_ATTR: &str = "asset";
 pub(crate) const ENTITY_ATTR: &str = "entity";
 pub(crate) const INPUT_ATTR: &str = "input";
 pub(crate) const FROM_ATTR: &str = "from";
 pub(crate) const INTO_ATTR: &str = "into";
-pub(crate) const ATTR_ATTR: &str = "attr";
 
 /// Ident for the `Schematic::Input` argument.
 pub(crate) const INPUT_IDENT: ConstIdent = ConstIdent("__input__");

--- a/examples/derive_schematic.rs
+++ b/examples/derive_schematic.rs
@@ -71,10 +71,10 @@ struct Foo<T: Reflect + TypePath> {
     /// It also uses the `from` attribute:
     #[schematic(from=String)]
     complex_from: EntityGroup,
-    /// To pass attributes to the generated input type,
-    /// we can use the `attr` argument on both fields and the container itself:
+    /// To pass attributes to the generated input type (both the field and the container),
+    /// we can use the dedicated `schematic_attr` attribute:
     #[reflect(ignore)]
-    #[schematic(attr(reflect(ignore)))]
+    #[schematic_attr(reflect(ignore))]
     _phantom: PhantomData<T>,
 }
 

--- a/examples/derive_schematic.rs
+++ b/examples/derive_schematic.rs
@@ -71,13 +71,14 @@ struct Foo<T: Reflect + TypePath> {
     /// It also uses the `from` attribute:
     #[schematic(from=String)]
     complex_from: EntityGroup,
-    /// As a side note, all reflection attributes get passed to the generated
-    /// input type.
+    /// To pass attributes to the generated input type,
+    /// we can use the `attr` argument on both fields and the container itself:
     #[reflect(ignore)]
+    #[schematic(attr(reflect(ignore)))]
     _phantom: PhantomData<T>,
 }
 
-#[derive(Reflect)]
+#[derive(Reflect, Clone)]
 struct EntityGroup(Vec<Entity>);
 
 // This implementation allows us to get a group of entities from the world
@@ -133,24 +134,21 @@ impl<T: ToString> From<T> for Bar {
 //         inlinable_asset: bevy_proto::backend::assets::InlinableProtoAsset<Mesh>,
 //         unique_inlinable_asset: bevy_proto::backend::assets::InlinableProtoAsset<Mesh>,
 //         entity: bevy_proto::backend::tree::EntityAccess,
-//         optional_entity: ::core::option::Option<bevy_proto::backend::tree::EntityAccess>,
 //         simple_from: [f32; 3],
 //         complex_from: String,
-//         #[reflect(ignore)]
-//         _phantom: PhantomData<T>,
+//         #[reflect(ignore)] _phantom: PhantomData<T>,
 //         #[reflect(ignore)] __phantom_ty__: ::core::marker::PhantomData<fn() -> ( T )>,
 //     }
 //     impl<T: Reflect + TypePath> bevy_proto::backend::schematics::FromSchematicInput<FooInput<T>> for Foo<T> {
 //         fn from_input(__input__: FooInput<T>, __id__: bevy_proto::backend::schematics::SchematicId, __context__: &mut bevy_proto::backend::schematics::SchematicContext) -> Self {
 //             Self {
-//                 lazy_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.lazy_asset, __id__.next(293524038300580229578133688495471229829u128), __context__),
-//                 preloaded_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.preloaded_asset, __id__.next(259350747728244782380707855355652559683u128), __context__),
-//                 inlinable_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.inlinable_asset, __id__.next(48963966091049860937914560587468761412u128), __context__),
+//                 lazy_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.lazy_asset, __id__.next(315625636512882385058417582115465912573u128), __context__),
+//                 preloaded_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.preloaded_asset, __id__.next(274759083279124148346925450125939914065u128), __context__),
+//                 inlinable_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.inlinable_asset, __id__.next(256227455035346537265969956879862545554u128), __context__),
 //                 unique_inlinable_asset: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.unique_inlinable_asset, __id__.next(::bevy::utils::Uuid::new_v4()), __context__),
-//                 entity: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.entity, __id__.next(38588287447872267661218663746081020914u128), __context__),
-//                 optional_entity: __input__.optional_entity.map(|__temp__| bevy_proto::backend::schematics::FromSchematicInput::from_input(__temp__, __id__.next(178921740518815055179893928029960888537u128), __context__)),
-//                 simple_from: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.simple_from, __id__.next(154624900170493169361666255879888812087u128), __context__),
-//                 complex_from: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.complex_from, __id__.next(97324268160146727710221744064890112339u128), __context__),
+//                 entity: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.entity, __id__.next(12442042730015606647024197521135919140u128), __context__),
+//                 simple_from: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.simple_from, __id__.next(255894236492372814614208583312628750442u128), __context__),
+//                 complex_from: bevy_proto::backend::schematics::FromSchematicInput::from_input(__input__.complex_from, __id__.next(158834411646179188492737822212966092653u128), __context__),
 //                 _phantom: __input__._phantom,
 //             }
 //         }
@@ -159,14 +157,14 @@ impl<T: ToString> From<T> for Bar {
 //         type Input = FooInput<T>;
 //         fn apply(__input__: &Self::Input, __id__: bevy_proto::backend::schematics::SchematicId, __context__: &mut bevy_proto::backend::schematics::SchematicContext) {
 //             let __input__ = <Self::Input as ::bevy::reflect::FromReflect>::from_reflect(&*::bevy::reflect::Reflect::clone_value(__input__)).unwrap_or_else(|| { panic!("{} should have a functioning `FromReflect` impl", std::any::type_name::<Self::Input>()) });
-//             let __input__ = <Self as bevy_proto::backend::schematics::FromSchematicInput<Self::Input>>::from_input(__input__, __id__.next(124079712295037166834829694552442065145u128), __context__);
+//             let __input__ = <Self as bevy_proto::backend::schematics::FromSchematicInput<Self::Input>>::from_input(__input__, __id__.next(1698037882055909450320189415164410880u128), __context__);
 //             __context__.entity_mut().unwrap_or_else(|| panic!("schematic `{}` expected entity", std::any::type_name::<Self>())).insert(__input__);
 //         }
 //         fn remove(__input__: &Self::Input, __id__: bevy_proto::backend::schematics::SchematicId, __context__: &mut bevy_proto::backend::schematics::SchematicContext) { __context__.entity_mut().unwrap_or_else(|| panic!("schematic `{}` expected entity", std::any::type_name::<Self>())).remove::<Self>(); }
 //         fn preload_dependencies(__input__: &mut Self::Input, __id__: bevy_proto::backend::schematics::SchematicId, __context__: &mut bevy_proto::backend::deps::DependenciesBuilder) {
 //             __input__.preloaded_asset = {
 //                 let __temp__ = <bevy_proto::backend::assets::ProtoAsset<Image> as ::bevy::reflect::FromReflect>::from_reflect(&*::bevy::reflect::Reflect::clone_value(&__input__.preloaded_asset)).unwrap_or_else(|| { panic!("{} should have a functioning `FromReflect` impl", ::std::any::type_name::<Image>()) });
-//                 bevy_proto::backend::assets::ProtoAsset::Handle(bevy_proto::backend::schematics::FromSchematicPreloadInput::from_preload_input(__temp__, __id__.next(103128525922241248568468580724045435516u128), __context__))
+//                 bevy_proto::backend::assets::ProtoAsset::Handle(bevy_proto::backend::schematics::FromSchematicPreloadInput::from_preload_input(__temp__, __id__.next(143686424131491485342302652144513517898u128), __context__))
 //             };
 //         }
 //     }


### PR DESCRIPTION
# Objective

Resolves #53

# Solution

Adds the `schematic_attr` and `asset_schematic_attr` attributes to the `Schematic` and `AssetSchematic` derives, respectively. This allows attributes to be forwarded to the generated input type.

For example, take the following schematic:

```rust
#[derive(Component, Schematic, Reflect)]
#[schematic_attr(
  derive(Default),
  reflect(Default),
)]
struct MyStruct {
  #[schematic(from = u8)]
  data: u32,
  #[schematic_attr(reflect(ignore))]
  hash: u64,
}
```

Will now generate an input type like:

```rust
#[derive(Reflect)]
#[derive(Default)]
#[reflect(Default)]
struct MyStructInput {
  data: u8,
  #[reflect(ignore)] 
  hash: u64,
}
```

---

This also means that reflection attributes are no longer automatically passed to the input type. That behavior was removed as it would sometimes result in invalid behavior and was also not very flexible.