### PR TITLE
Using proper feature name for bevy scene schemantics registration

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -33,7 +33,7 @@ pub(crate) fn register_custom_schematics(app: &mut App) {
     );
     #[cfg(feature = "bevy_render")]
     register_schematic!(app, VisibilityBundle, SpatialBundle);
-    #[cfg(feature = "bevy_sprite")]
+    #[cfg(feature = "bevy_scene")]
     register_schematic!(app, DynamicSceneBundle, SceneBundle);
     #[cfg(feature = "bevy_sprite")]
     register_schematic!(


### PR DESCRIPTION
Bevy scene struct schematics registration required "bevy_sprite" feature instead of "bevy_scene".